### PR TITLE
✨ Feat: ServiceCard 컴포넌트 및 관련 타입 / 스타일 / 스토리북 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,25 +7,30 @@ import storybook from 'eslint-plugin-storybook';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
-  [
-    { ignores: ['dist'] },
-    {
-      extends: [js.configs.recommended, ...tseslint.configs.recommended, prettierConfig],
-      files: ['**/*.{ts,tsx}'],
-      languageOptions: {
-        ecmaVersion: 2020,
-        globals: globals.browser,
-      },
-      plugins: {
-        'react-hooks': reactHooks,
-        'react-refresh': reactRefresh,
-      },
-      rules: {
-        ...reactHooks.configs.recommended.rules,
-        'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-      },
-    },
-  ],
+export default tseslint.config([
+  { ignores: ['dist'] },
   storybook.configs['flat/recommended'],
-);
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended, prettierConfig],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  {
+    files: ['**/*.stories.@(js|jsx|ts|tsx|mdx)', '**/*.story.@(js|jsx|ts|tsx|mdx)'],
+    // plugins: { storybook }, // <- 없어도 됩니다(위에서 이미 등록됨)
+    rules: {
+      'storybook/no-renderer-packages': 'off',
+    },
+  },
+]);

--- a/src/components/ServiceCard.stories.tsx
+++ b/src/components/ServiceCard.stories.tsx
@@ -1,0 +1,64 @@
+import type { Service } from '@/types/service';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ServiceCard from './ServiceCard';
+
+const meta = {
+  title: 'Components/ServiceCard',
+  component: ServiceCard,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ServiceCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 샘플 데이터
+const sample: Service = {
+  id: 'complaint',
+  title: '고소장 작성하기',
+  icon: 'edit_note',
+  to: '/complaint',
+};
+
+export const Default: Story = {
+  args: {
+    service: sample,
+  },
+};
+
+export const Hover: Story = {
+  args: {
+    service: sample,
+  },
+  // 스토리북 인터랙션으로 :hover 상태를 재현
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector('[role="button"]') as HTMLElement;
+    // mouseover 이벤트로 hover 유도
+    card?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+  },
+};
+
+export const Focus: Story = {
+  args: {
+    service: sample,
+  },
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector('[role="button"]') as HTMLElement;
+    card?.focus();
+  },
+};
+
+export const KeyboardActivate: Story = {
+  args: {
+    service: sample,
+  },
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector('[role="button"]') as HTMLElement;
+    card?.focus();
+    // Space/Enter 키로 onClick 트리거 되는지 확인 (Actions 패널에서 "clicked" 이벤트 확인)
+    card?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    card?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+  },
+};

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,0 +1,59 @@
+import type { Service } from '@/types/service';
+import React from 'react';
+
+type Props = { service: Service; onClick?: (s: Service) => void };
+
+const ServiceCard: React.FC<Props> = ({ service, onClick }) => (
+  <div
+    role="button"
+    tabIndex={0}
+    onClick={() => onClick?.(service)}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') onClick?.(service);
+    }}
+    className={[
+      // 크기 & 레이아웃
+      'group inline-flex h-[220px] w-[360px] items-center justify-center',
+      'rounded-2xl bg-white',
+      // 기본 섀도우
+      'shadow-[0_4px_12px_rgba(0,0,0,0.1)]',
+      // hover: 배경/섀도우 색 변경
+      'transition-all duration-300',
+      'hover:bg-blue-50/[0.35]',
+      'hover:shadow-[0_4px_12px_rgba(37,99,235,0.1)]',
+      // 포커스 접근성
+      'focus:ring-2 focus:ring-blue-500/40 focus:outline-none',
+    ].join(' ')}
+  >
+    <div className="flex flex-col items-center gap-3 text-center">
+      <span
+        className={[
+          'material-symbols-outlined',
+          '!text-[120px]',
+          // 기본 아이콘 컬러
+          'text-slate-900',
+          // hover 시 아이콘 컬러
+          'group-hover:text-blue-600',
+          'transition-colors',
+        ].join(' ')}
+        aria-hidden
+      >
+        {service.icon}
+      </span>
+
+      <h3
+        className={[
+          // 텍스트 32px, medium, 중앙, 기본색
+          'text-[32px] font-medium text-slate-900',
+          // hover 시 텍스트 색
+          'group-hover:text-blue-600',
+          'transition-colors duration-300',
+        ].join(' ')}
+      >
+        {service.title}
+      </h3>
+    </div>
+  </div>
+);
+
+export default ServiceCard;

--- a/src/constants/service.ts
+++ b/src/constants/service.ts
@@ -1,0 +1,7 @@
+import type { Service } from '@/types/service';
+
+export const SERVICES: Service[] = [
+  { id: 'complaint', title: '고소장 작성하기', icon: 'edit_note', to: '/complaint' },
+  { id: 'precedent', title: '판례 찾아보기', icon: 'content_paste_search', to: '/precedent' },
+  { id: 'faq', title: '자주 하는 질문', icon: 'contact_support', to: '/faq' },
+];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import App from './App.tsx';
-import './index.css';
+import './styles/tailwind.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,9 @@
+@import 'tailwindcss';
+
+@theme {
+  /* 폰트 패밀리 */
+  --font-sans:
+    'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, 'Apple Color Emoji',
+    Arial, sans-serif, 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Sans KR', 'Apple SD Gothic Neo',
+    '맑은 고딕', 'Malgun Gothic';
+}

--- a/src/types/service.d.ts
+++ b/src/types/service.d.ts
@@ -1,0 +1,8 @@
+export type ServiceId = 'complaint' | 'precedent' | 'faq';
+
+export interface Service {
+  id: ServiceId;
+  title: string;
+  icon: string;
+  to?: string;
+}


### PR DESCRIPTION
### ✅ PR 설명

ServiceCard 컴포넌트 및 관련 환경 세팅을 추가

### 🏗 작업 내용

- [x] Service 도메인 타입 정의 추가
- [x] 서비스 상수(SERVICES) 추가 및 분리
- [x] 전역 Tailwind 스타일 파일 추가 및 Pretendard 테마 등록
- [x] 앱 엔트리에서 전역 Tailwind 스타일 적용
- [x] ServiceCard 컴포넌트 추가
- [x] ServiceCard 스토리북 스토리 추가

### 📸 테스트 결과 (선택)

> <img width="943" height="545" alt="image" src="https://github.com/user-attachments/assets/4d738dff-c90c-440a-9761-7a5988a91e03" />

### 🔗 관련 이슈 (선택)

> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
