### PR TITLE
[Refactor] 버튼 컴포넌트 추가 및 기존 버튼 코드들에 적용

### DIFF
--- a/src/components/CharacterModal.tsx
+++ b/src/components/CharacterModal.tsx
@@ -1,4 +1,5 @@
 import LogoUrl from '@/assets/BaLawCharacter-large.svg';
+import Button from '@/components/common/Button';
 import React from 'react';
 
 type Variant = 'login' | 'exit' | 'delete';
@@ -52,33 +53,6 @@ const CharacterModal: React.FC<Props> = ({ variant = 'login', onCancel, onConfir
     leftButtonText = '취소';
     rightButtonText = '삭제할게요';
   }
-  const rightButtonClasses = isLogin
-    ? [
-        'h-10 w-20 sm:h-12 sm:w-28',
-        'rounded-200 bg-positive-0 hover:bg-positive-100 text-neutral-900',
-        'text-detail-bold sm:text-body-3-bold',
-        'transition-colors duration-200',
-      ].join(' ')
-    : [
-        'h-10 w-20 sm:h-12 sm:w-28',
-        'rounded-200 bg-warning-200 hover:bg-warning-300 text-neutral-100',
-        'text-detail-regular sm:text-body-3-regular',
-        'transition-colors duration-200',
-      ].join(' ');
-
-  const leftButtonClasses = isLogin
-    ? [
-        'h-10 w-20 sm:h-12 sm:w-28',
-        'rounded-200 bg-warning-200 hover:bg-warning-300 text-neutral-100',
-        'text-detail-regular sm:text-body-3-regular',
-        'transition-colors duration-200',
-      ].join(' ')
-    : [
-        'h-10 w-20 sm:h-12 sm:w-28',
-        'rounded-200 bg-positive-0 hover:bg-positive-100 text-neutral-900',
-        'text-detail-bold sm:text-body-3-bold',
-        'transition-colors duration-200',
-      ].join(' ');
 
   return (
     <div
@@ -115,19 +89,23 @@ const CharacterModal: React.FC<Props> = ({ variant = 'login', onCancel, onConfir
           className="h-52 w-52 object-contain"
         />
 
-        <div className="flex gap-6 sm:gap-10">
-          <button
+        <div className="flex w-full items-center justify-center gap-4">
+          <Button
+            variant="secondary"
+            size="md"
+            fullWidth
             onClick={onCancel}
-            className={leftButtonClasses}
           >
             {leftButtonText}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="error"
+            size="md"
+            fullWidth
             onClick={onConfirm}
-            className={rightButtonClasses}
           >
             {rightButtonText}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/CharacterModal.tsx
+++ b/src/components/CharacterModal.tsx
@@ -91,7 +91,7 @@ const CharacterModal: React.FC<Props> = ({ variant = 'login', onCancel, onConfir
 
         <div className="flex w-full items-center justify-center gap-4">
           <Button
-            variant="secondary"
+            variant={isLogin ? 'error' : 'secondary'}
             size="md"
             fullWidth
             onClick={onCancel}
@@ -99,7 +99,7 @@ const CharacterModal: React.FC<Props> = ({ variant = 'login', onCancel, onConfir
             {leftButtonText}
           </Button>
           <Button
-            variant="error"
+            variant={isLogin ? 'secondary' : 'error'}
             size="md"
             fullWidth
             onClick={onConfirm}

--- a/src/components/DaumPostcodeButton.tsx
+++ b/src/components/DaumPostcodeButton.tsx
@@ -1,3 +1,4 @@
+import Button from '@/components/common/Button';
 import React, { useState } from 'react';
 
 declare global {
@@ -47,18 +48,13 @@ const DaumPostcodeButton: React.FC<Props> = ({ onSelect }) => {
 
   return (
     <>
-      <button
-        type="button"
+      <Button
+        variant="outline"
+        size="sm"
         onClick={handleOpen}
-        className={[
-          'rounded-200 text-detail-regular h-8 border px-3',
-          'border-primary-400 bg-primary-0/50 hover:bg-primary-50/50',
-          'active:bg-primary-100 active:border-primary-200 active:text-primary-700',
-          'transition-all active:scale-95',
-        ].join(' ')}
       >
         주소 찾기
-      </button>
+      </Button>
 
       {/* open=true일 때 모달/오버레이로 띄우고 싶으면 여기서 다룸 */}
       {open && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -63,7 +63,7 @@ const Header: React.FC = () => {
       {/* 로그인 여부(user 존재 여부)에 따라 버튼 분기 */}
       <Button
         variant="outline"
-        size="md"
+        size="sm"
         className="w-20"
         onClick={buttonAction}
       >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@
  */
 import { logout } from '@/apis/auth';
 import logoUrl from '@/assets/BaLawLogo.svg';
+import Button from '@/components/common/Button';
 import { useComplaintWizard } from '@/stores/useComplaintWizard';
 import { useUserStore } from '@/stores/useUserStore';
 import React from 'react';
@@ -21,12 +22,12 @@ const Header: React.FC = () => {
   // 고소장 위자드 reset 함수
   const resetWizard = useComplaintWizard((s) => s.reset);
 
-  // 로그인 버튼 클릭 → /login 페이지 이동
+  // 로그인 버튼 클릭 -> /login 페이지 이동
   const handleLoginClick = () => {
     navigate('/login');
   };
 
-  // 로고 클릭 → 홈('/') 이동
+  // 로고 클릭 -> 홈('/') 이동
   const handleLogoClick = () => {
     resetWizard();
     navigate('/');
@@ -42,9 +43,6 @@ const Header: React.FC = () => {
   const isLogin = Boolean(user);
   const buttonText = isLogin ? '로그아웃' : '로그인';
   const buttonAction = isLogin ? handleLogoutClick : handleLoginClick;
-
-  const buttonClass =
-    'flex h-11 w-20 items-center justify-center gap-2.5 rounded-300 bg-primary-900 px-2 py-2 transition hover:bg-primary-800';
 
   return (
     /**
@@ -63,12 +61,14 @@ const Header: React.FC = () => {
       />
 
       {/* 로그인 여부(user 존재 여부)에 따라 버튼 분기 */}
-      <button
+      <Button
+        variant="outline"
+        size="md"
+        className="w-20"
         onClick={buttonAction}
-        className={buttonClass}
       >
-        <span className="text-body-3-regular text-neutral-0 font-medium">{buttonText}</span>{' '}
-      </button>
+        {buttonText}
+      </Button>
     </header>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,6 +43,7 @@ const Header: React.FC = () => {
   const isLogin = Boolean(user);
   const buttonText = isLogin ? '로그아웃' : '로그인';
   const buttonAction = isLogin ? handleLogoutClick : handleLoginClick;
+  const buttonVariant = isLogin ? 'outline-secondary' : 'outline';
 
   return (
     /**
@@ -62,7 +63,7 @@ const Header: React.FC = () => {
 
       {/* 로그인 여부(user 존재 여부)에 따라 버튼 분기 */}
       <Button
-        variant="outline"
+        variant={buttonVariant}
         size="sm"
         className="w-20"
         onClick={buttonAction}

--- a/src/components/WizardNavButtons.tsx
+++ b/src/components/WizardNavButtons.tsx
@@ -1,3 +1,4 @@
+import Button from '@/components/common/Button';
 import React from 'react';
 
 type WizardNavButtonsProps = {
@@ -17,42 +18,27 @@ const WizardNavButtons: React.FC<WizardNavButtonsProps> = ({
   prevLabel = '이전',
   nextLabel = '다음',
 }) => {
-  const baseBtn =
-    'rounded-200 text-body-3-bold flex h-12 w-[220px] items-center justify-center px-6 py-[9px]';
-
-  const prevBtnClass = [
-    baseBtn,
-    disablePrev
-      ? 'bg-primary-200 cursor-not-allowed text-neutral-50 opacity-60'
-      : 'bg-primary-400 text-neutral-0',
-  ].join(' ');
-
-  const nextBtnClass = [
-    baseBtn,
-    isNextDisabled
-      ? 'bg-primary-200 cursor-not-allowed text-neutral-50 opacity-60'
-      : 'bg-primary-400 text-neutral-0',
-  ].join(' ');
-
   return (
     <div className="mx-auto flex w-full max-w-[420px] items-center justify-center">
       <div className="flex w-full items-center justify-between gap-3">
-        <button
-          type="button"
-          onClick={!disablePrev ? onPrev : undefined}
+        <Button
+          variant="primary"
+          size="md"
+          fullWidth
+          onClick={onPrev}
           disabled={disablePrev}
-          className={prevBtnClass}
         >
           {prevLabel}
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
+          fullWidth
           onClick={onNext}
           disabled={isNextDisabled}
-          className={nextBtnClass}
         >
           {nextLabel}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/agreements/AgreementsCard.tsx
+++ b/src/components/agreements/AgreementsCard.tsx
@@ -1,3 +1,4 @@
+import Button from '@/components/common/Button';
 import type { Agreement } from '@/types/agreement';
 import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -89,19 +90,16 @@ const AgreementsCard: React.FC<Props> = ({ initial }) => {
       </div>
 
       {/* 버튼 */}
-      <button
+      <Button
+        variant="primary"
+        size="md"
+        fullWidth
         type="submit"
+        disabled={!requiredAllChecked}
         aria-disabled={!requiredAllChecked}
-        className={[
-          'h-12 w-full items-center justify-center px-5',
-          'rounded-200 text-body-3-bold text-neutral-0 transition-colors',
-          requiredAllChecked
-            ? 'bg-primary-400 hover:bg-primary-600'
-            : 'bg-primary-400 cursor-not-allowed opacity-60',
-        ].join(' ')}
       >
         회원가입 진행하기
-      </button>
+      </Button>
     </form>
   );
 };

--- a/src/components/auth/LoginCard.tsx
+++ b/src/components/auth/LoginCard.tsx
@@ -1,4 +1,5 @@
 import FormErrorMessage from '@/components/FormErrorMessage';
+import Button from '@/components/common/Button';
 import type { LoginCardProps, LoginFormValues } from '@/types/auth';
 import React, { useState } from 'react';
 
@@ -66,7 +67,7 @@ const LoginCard: React.FC<LoginCardProps> = ({ className = '', onLogin }) => {
               type="email"
               placeholder="이메일 주소"
               className={[
-                'rounded-200 h-10 flex-1 px-3',
+                'rounded-200 h-12 flex-1 px-3',
                 'border border-neutral-300',
                 'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
               ].join(' ')}
@@ -92,7 +93,7 @@ const LoginCard: React.FC<LoginCardProps> = ({ className = '', onLogin }) => {
               type="password"
               placeholder="비밀번호"
               className={[
-                'rounded-200 h-10 flex-1 px-3',
+                'rounded-200 h-12 flex-1 px-3',
                 'border border-neutral-300',
                 'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
               ].join(' ')}
@@ -109,20 +110,15 @@ const LoginCard: React.FC<LoginCardProps> = ({ className = '', onLogin }) => {
       <FormErrorMessage error={error} />
 
       {/* 로그인 버튼 */}
-      <button
-        type="button"
+      <Button
+        variant="primary"
+        size="md"
+        fullWidth
         disabled={loading}
-        onClick={() => handleSubmit()}
-        className={[
-          'h-12 w-full items-center justify-center px-5',
-          'rounded-200 text-body-3-bold text-neutral-0 transition-colors',
-          loading
-            ? 'bg-primary-400 cursor-not-allowed opacity-60'
-            : 'bg-primary-400 hover:bg-primary-600',
-        ].join(' ')}
+        onClick={handleSubmit}
       >
         {loading ? '로그인 중...' : '로그인'}
-      </button>
+      </Button>
 
       {/* 회원가입 안내 */}
       <div className="mt-10 flex flex-col items-center gap-2">

--- a/src/components/auth/SignupAccountCard.tsx
+++ b/src/components/auth/SignupAccountCard.tsx
@@ -1,5 +1,6 @@
 import { checkEmailAvailability } from '@/apis/auth';
 import FormErrorMessage from '@/components/FormErrorMessage';
+import Button from '@/components/common/Button';
 import React, { useState } from 'react';
 
 type Props = {
@@ -140,7 +141,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
                 id="email"
                 type="email"
                 className={[
-                  'rounded-200 h-10 flex-1 px-3',
+                  'rounded-200 h-12 flex-1 px-3',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -154,23 +155,18 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
               />
 
               {/* 중복 확인 버튼 */}
-              <button
-                type="button"
+              <Button
+                variant="secondary"
+                size="md"
+                disabled={emailCheckStatus !== 'idle'}
                 onClick={handleEmailCheck}
-                disabled={!email} // 이메일 입력 안 했으면 비활성화
-                className={[
-                  'rounded-200 text-detail-regular h-10 border px-2 whitespace-nowrap transition-colors',
-                  !email
-                    ? 'cursor-not-allowed border-neutral-300 bg-neutral-100 text-neutral-400'
-                    : 'border-primary-400 text-primary-400 hover:bg-primary-0/50',
-                ].join(' ')}
               >
                 {emailCheckStatus === 'checking'
                   ? '확인 중...'
                   : emailCheckStatus === 'success'
                     ? '확인 완료'
                     : '중복 확인'}
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -190,7 +186,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
                 id="password"
                 type={showPw ? 'text' : 'password'}
                 className={[
-                  'rounded-200 h-10 w-full px-3 pr-10',
+                  'rounded-200 h-12 w-full px-3 pr-10',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -232,7 +228,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
                 id="password2"
                 type={showPwCheck ? 'text' : 'password'}
                 className={[
-                  'rounded-200 h-10 w-full px-3 pr-10',
+                  'rounded-200 h-12 w-full px-3 pr-10',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -263,19 +259,16 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
       <FormErrorMessage error={error} />
 
       {/* 다음 단계 버튼 */}
-      <button
-        type="submit"
+      <Button
+        variant="primary"
+        size="md"
+        fullWidth
         disabled={isNextDisabled}
-        className={[
-          'h-12 w-full items-center justify-center px-5',
-          'rounded-200 text-body-3-bold text-neutral-0 transition-colors',
-          !email || !pw || !pwCheck
-            ? 'bg-primary-400 cursor-not-allowed opacity-60'
-            : 'bg-primary-400 hover:bg-primary-600',
-        ].join(' ')}
+        type="submit"
+        aria-disabled={isNextDisabled}
       >
         다음
-      </button>
+      </Button>
     </form>
   );
 };

--- a/src/components/auth/SignupProfileCard.tsx
+++ b/src/components/auth/SignupProfileCard.tsx
@@ -1,5 +1,6 @@
 import DaumPostcodeButton from '@/components/DaumPostcodeButton';
 import FormErrorMessage from '@/components/FormErrorMessage';
+import Button from '@/components/common/Button';
 import React, { useState } from 'react';
 
 type SignupProfileData = {
@@ -60,7 +61,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
     setError(null);
 
     // 필수값 검증
-    if (!name) {
+    if (!name || !city || !district || !town || !phone1 || !phone2 || !phone3) {
       setError('필수 항목들을 모두 입력해주세요.');
       return;
     }
@@ -103,8 +104,24 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
         'flex flex-col',
       ].join(' ')}
     >
-      {/* 제목 */}
-      <h2 className="text-heading-1-bold text-primary-400 text-center">회원가입</h2>
+      {/* 제목 + 이전 버튼 */}
+      <div className="relative flex items-center justify-center">
+        <button
+          type="button"
+          onClick={() =>
+            onBack({ name, city, district, town, phone: [phone1, phone2, phone3].join('').trim() })
+          }
+          className="absolute left-0 flex items-center text-neutral-400 hover:text-neutral-600"
+        >
+          <span
+            className="material-symbols-outlined"
+            style={{ fontSize: '28px' }}
+          >
+            chevron_left
+          </span>
+        </button>
+        <h2 className="text-heading-1-bold text-primary-400 text-center">회원가입</h2>
+      </div>
 
       {/* 입력 폼 */}
       <div className="mt-15 flex flex-1 flex-col justify-center gap-6 px-5">
@@ -123,7 +140,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
               placeholder="홍길동"
               type="name"
               className={[
-                'rounded-200 w- h-10 flex-1 px-3',
+                'rounded-200 w- h-12 flex-1 px-3',
                 'border border-neutral-300',
                 'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
               ].join(' ')}
@@ -164,7 +181,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 onClick={handleAddressFieldClick}
                 onFocus={handleAddressFieldClick}
                 className={[
-                  'rounded-200 w- h-10 flex-1 px-3 text-center',
+                  'rounded-200 w- h-12 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   hasAddress ? 'bg-neutral-0' : 'cursor-not-allowed bg-neutral-50',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
@@ -179,7 +196,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 onClick={handleAddressFieldClick}
                 onFocus={handleAddressFieldClick}
                 className={[
-                  'rounded-200 w- h-10 flex-1 px-3 text-center',
+                  'rounded-200 w- h-12 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   hasAddress ? 'bg-neutral-0' : 'cursor-not-allowed bg-neutral-50',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
@@ -194,7 +211,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 onClick={handleAddressFieldClick}
                 onFocus={handleAddressFieldClick}
                 className={[
-                  'rounded-200 w- h-10 flex-1 px-3 text-center',
+                  'rounded-200 w- h-12 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   hasAddress ? 'bg-neutral-0' : 'cursor-not-allowed bg-neutral-50',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
@@ -228,7 +245,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 value={phone1}
                 onChange={(e) => setPhone1(e.target.value)}
                 className={[
-                  'rounded-200 w- h-10 flex-1 px-3 text-center',
+                  'rounded-200 w- h-12 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -241,7 +258,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 value={phone2}
                 onChange={(e) => setPhone2(e.target.value)}
                 className={[
-                  'rounded-200 w- h-10 flex-1 px-3 text-center',
+                  'rounded-200 w- h-12 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -254,7 +271,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 value={phone3}
                 onChange={(e) => setPhone3(e.target.value)}
                 className={[
-                  'rounded-200 w- h-10 flex-1 px-3 text-center',
+                  'rounded-200 w- h-12 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -267,33 +284,16 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
       {/* 경고 문구 */}
       <FormErrorMessage error={error} />
 
-      <div className="flex gap-4">
-        <button
-          type="button"
-          onClick={() =>
-            onBack({ name, city, district, town, phone: [phone1, phone2, phone3].join('').trim() })
-          }
-          className={[
-            'h-12 flex-1 items-center justify-center',
-            'rounded-200 border-primary-400 border',
-            'text-body-3-bold text-primary-400 transition-colors',
-          ].join(' ')}
-        >
-          이전
-        </button>
-        <button
-          type="submit"
-          className={[
-            'h-12 flex-1 items-center justify-center',
-            'rounded-200 text-body-3-bold text-neutral-0 transition-colors',
-            !name
-              ? 'bg-primary-400 cursor-not-allowed opacity-60'
-              : 'bg-primary-400 hover:bg-primary-600',
-          ].join(' ')}
-        >
-          {isSubmitting ? '회원가입 진행중...' : '회원가입'}
-        </button>
-      </div>
+      <Button
+        variant="primary"
+        size="md"
+        fullWidth
+        disabled={
+          isSubmitting || !name || !city || !district || !town || !phone1 || !phone2 || !phone3
+        }
+      >
+        {isSubmitting ? '회원가입 진행중...' : '회원가입'}
+      </Button>
     </form>
   );
 };

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type ButtonVariant = 'primary' | 'secondary' | 'error' | 'outline';
+type ButtonVariant = 'primary' | 'secondary' | 'error' | 'outline' | 'outline-secondary';
 type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -44,6 +44,11 @@ const Button: React.FC<ButtonProps> = ({
       'border border-primary-400 text-primary-400 bg-white',
       'hover:bg-primary-0/50 hover:border-primary-500',
       'active:bg-primary-50/70 active:border-primary-600',
+    ].join(' '),
+    'outline-secondary': [
+      'border border-neutral-200 text-neutral-700',
+      'hover:border-neutral-300',
+      'active:border-neutral-350',
     ].join(' '),
   };
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type ButtonVariant = 'primary' | 'secondary' | 'error';
+type ButtonVariant = 'primary' | 'secondary' | 'error' | 'outline';
 type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -27,7 +27,7 @@ const Button: React.FC<ButtonProps> = ({
     'whitespace-nowrap',
   ].join(' ');
 
-  // 색상 (primary, error, secondary)
+  // 색상 (primary, error, secondary, outline)
   const variantStyles = {
     primary: [
       'bg-primary-400 text-neutral-0',
@@ -39,6 +39,11 @@ const Button: React.FC<ButtonProps> = ({
       'bg-neutral-200 text-neutral-700',
       'hover:bg-neutral-300',
       'active:bg-neutral-350',
+    ].join(' '),
+    outline: [
+      'border border-primary-400 text-primary-400 bg-white',
+      'hover:bg-primary-0/50 hover:border-primary-500',
+      'active:bg-primary-50/70 active:border-primary-600',
     ].join(' '),
   };
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+type ButtonVariant = 'primary' | 'secondary' | 'error';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+  children: React.ReactNode;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  className = '',
+  children,
+  disabled,
+  ...props
+}) => {
+  // 공통 스타일
+  const baseStyles = [
+    'inline-flex items-center justify-center',
+    'transition-colors duration-200 ease-in-out',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    'whitespace-nowrap',
+  ].join(' ');
+
+  // 색상 (primary, error, secondary)
+  const variantStyles = {
+    primary: [
+      'bg-primary-400 text-neutral-0',
+      'hover:bg-primary-500',
+      'active:bg-primary-600',
+    ].join(' '),
+    error: ['bg-warning-200 text-neutral-0', 'hover:bg-warning-300', 'active:bg-red-700'].join(' '),
+    secondary: [
+      'bg-neutral-200 text-neutral-700',
+      'hover:bg-neutral-300',
+      'active:bg-neutral-350',
+    ].join(' '),
+  };
+
+  // 크기 변형 (높이, 패딩, 폰트, radius)
+  const sizeStyles = {
+    sm: 'h-8 px-2 text-detail-regular rounded-200', // 채팅 전송 버튼 등 작은 곳
+    md: 'h-12 px-3 text-body-3-regular rounded-200', // 일반적인 폼 버튼
+    lg: 'h-16 px-4 text-body-3-regular rounded-200', // 다운로드 버튼 등 큰 CTA
+  };
+
+  // 너비 설정
+  const widthStyle = fullWidth ? 'w-full' : '';
+
+  return (
+    <button
+      className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${widthStyle} ${className}`}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/pages/MyComplaintsPage.tsx
+++ b/src/pages/MyComplaintsPage.tsx
@@ -3,6 +3,7 @@ import CharacterModal from '@/components/CharacterModal';
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
 import IntroHeader from '@/components/IntroHeader';
+import Button from '@/components/common/Button';
 import { useComplaintWizard } from '@/stores/useComplaintWizard';
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -139,23 +140,17 @@ const MyComplaintsPage: React.FC = () => {
 
         {/* 오른쪽 상단 CTA 버튼 */}
         <div className="mb-4 flex justify-end">
-          <button
-            type="button"
+          <Button
+            variant="outline"
+            size="md"
             onClick={() => {
               resetWizard();
               navigate('/complaint');
             }}
-            className={[
-              'inline-flex items-center gap-1',
-              'rounded-300 border px-4 py-2',
-              'border-primary-300 bg-primary-25 text-body-3-bold text-primary-600',
-              'hover:bg-primary-50 hover:border-primary-400',
-              'transition-colors duration-200',
-            ].join(' ')}
           >
-            <span className="material-symbols-outlined text-primary-500">edit_document</span>새
+            <span className="material-symbols-outlined text-primary-500 mr-2">edit_document</span>새
             고소장 작성
-          </button>
+          </Button>
         </div>
 
         {/* 에러 메시지 */}
@@ -194,23 +189,15 @@ const MyComplaintsPage: React.FC = () => {
             <div className="flex h-52 flex-col items-center justify-center gap-3">
               <span className="material-symbols-outlined text-[40px] text-neutral-300">drafts</span>
               <p className="text-body-3-regular text-neutral-600">아직 작성한 고소장이 없어요.</p>
-              <button
-                type="button"
+              <Button
                 onClick={() => {
                   resetWizard();
                   navigate('/complaint');
                 }}
-                className={[
-                  'inline-flex items-center gap-1',
-                  'rounded-300 border px-4 py-2',
-                  'border-primary-300 bg-primary-25 text-body-3-bold text-primary-600',
-                  'hover:bg-primary-50 hover:border-primary-400',
-                  'transition-colors duration-200',
-                ].join(' ')}
               >
                 <span className="material-symbols-outlined text-primary-500">add</span>새 고소장
                 작성하러 가기
-              </button>
+              </Button>
             </div>
           ) : (
             <ul className="flex flex-col gap-3">
@@ -263,15 +250,10 @@ const MyComplaintsPage: React.FC = () => {
                     <div className="flex flex-wrap items-center gap-2 md:justify-end">
                       {/* 액션 버튼들 */}
                       {c.status === 'in_progress' ? (
-                        <button
-                          type="button"
+                        <Button
+                          variant="outline"
+                          size="sm"
                           onClick={() => handleResume(c)}
-                          className={[
-                            'rounded-300 inline-flex items-center gap-1 border px-3 py-1.5',
-                            'border-primary-100 bg-primary-25 text-detail-regular text-primary-600 font-semibold',
-                            'hover:bg-primary-0/50 hover:border-primary-100',
-                            'transition-colors duration-200',
-                          ].join(' ')}
                         >
                           <span
                             className="material-symbols-outlined text-primary-500"
@@ -280,21 +262,13 @@ const MyComplaintsPage: React.FC = () => {
                             play_arrow
                           </span>
                           이어 쓰기
-                        </button>
+                        </Button>
                       ) : (
-                        <button
-                          type="button"
+                        <Button
+                          variant="outline"
+                          size="sm"
                           onClick={() => canDownload && handleDownload(c)}
                           disabled={!canDownload || downloadingId === c.id}
-                          className={[
-                            'rounded-300 inline-flex items-center gap-1 border px-3 py-1.5',
-                            canDownload
-                              ? 'border-primary-100 bg-primary-25 text-detail-regular text-primary-600 font-semibold'
-                              : 'text-detail-regular border-neutral-200 bg-neutral-50 font-semibold text-neutral-400',
-                            'hover:bg-primary-0/50 hover:border-primary-100',
-                            'disabled:cursor-not-allowed disabled:opacity-60',
-                            'transition-colors duration-200',
-                          ].join(' ')}
                         >
                           <span
                             className="material-symbols-outlined"
@@ -307,20 +281,14 @@ const MyComplaintsPage: React.FC = () => {
                               ? '다운로드 중...'
                               : '고소장 다운로드'
                             : '다운로드 기간 만료'}
-                        </button>
+                        </Button>
                       )}
 
-                      <button
-                        type="button"
+                      <Button
+                        variant="secondary"
+                        size="sm"
                         onClick={() => handleDelete(c)}
                         disabled={deletingId === c.id}
-                        className={[
-                          'rounded-300 text-detail-regular inline-flex items-center gap-1 border px-3 py-1.5',
-                          'bg-neutral-0 border-neutral-200 text-neutral-500',
-                          'hover:border-warning-100 hover:bg-warning-0/50 hover:text-warning-200',
-                          'disabled:opacity-50 disabled:hover:border-neutral-200 disabled:hover:text-neutral-500',
-                          'transition-colors duration-200',
-                        ].join(' ')}
                       >
                         <span
                           className="material-symbols-outlined text-inherit"
@@ -329,7 +297,7 @@ const MyComplaintsPage: React.FC = () => {
                           delete
                         </span>
                         삭제
-                      </button>
+                      </Button>
                     </div>
                   </li>
                 );

--- a/src/pages/MyComplaintsPage.tsx
+++ b/src/pages/MyComplaintsPage.tsx
@@ -186,18 +186,14 @@ const MyComplaintsPage: React.FC = () => {
               </p>
             </div>
           ) : items.length === 0 ? (
-            <div className="flex h-52 flex-col items-center justify-center gap-3">
-              <span className="material-symbols-outlined text-[40px] text-neutral-300">drafts</span>
-              <p className="text-body-3-regular text-neutral-600">아직 작성한 고소장이 없어요.</p>
-              <Button
-                onClick={() => {
-                  resetWizard();
-                  navigate('/complaint');
-                }}
+            <div className="flex h-96 flex-col items-center justify-center gap-6">
+              <span
+                className="material-symbols-outlined text-neutral-200"
+                style={{ fontSize: '40px' }}
               >
-                <span className="material-symbols-outlined text-primary-500">add</span>새 고소장
-                작성하러 가기
-              </Button>
+                drafts
+              </span>
+              <p className="text-heading-3 text-neutral-400">아직 작성한 고소장이 없어요.</p>
             </div>
           ) : (
             <ul className="flex flex-col gap-3">

--- a/src/sections/ChatWindowSection.tsx
+++ b/src/sections/ChatWindowSection.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/apis/complaints';
 import type { ChatMetaPayload, RagCase } from '@/apis/complaints';
 import { ChatBubble } from '@/components/ChatBubble';
+import Button from '@/components/common/Button';
 import type { Side } from '@/types/side';
 import type { AxiosError } from 'axios';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -500,19 +501,15 @@ const ChatWindowSection: React.FC<Props> = ({
             'focus:outline-none disabled:opacity-50',
           ].join(' ')}
         />
-        <button
-          type="button"
+        <Button
+          variant="primary"
+          size="sm"
+          className="w-16"
           onClick={handleSend}
           disabled={inputDisabled || !input.trim()}
-          className={[
-            'flex h-9 items-center justify-center',
-            'rounded-400 border-primary-400 bg-primary-50 border-2',
-            'text-body-3-bold text-primary-400',
-            'px-3 disabled:opacity-40',
-          ].join(' ')}
         >
           전송
-        </button>
+        </Button>
       </div>
     </section>
   );

--- a/src/sections/ComplaintDownloadSection.tsx
+++ b/src/sections/ComplaintDownloadSection.tsx
@@ -1,6 +1,7 @@
 import { downloadComplaintDocx } from '@/apis/complaints';
 import DocxIcon from '@/assets/Docs.svg';
 import IntroHeader from '@/components/IntroHeader';
+import Button from '@/components/common/Button';
 import React, { useState } from 'react';
 
 type ComplaintDownloadSectionProps = {
@@ -80,18 +81,12 @@ const ComplaintDownloadSection: React.FC<ComplaintDownloadSectionProps> = ({ com
 
         {/* 버튼 영역 */}
         <div className="mt-auto flex flex-col items-center gap-3">
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="md"
+            fullWidth
             onClick={handleDownload}
             disabled={isDownloading}
-            className={[
-              'flex h-12 w-full items-center justify-center gap-2',
-              'rounded-400 bg-primary-500 px-6',
-              'text-body-3-bold text-neutral-0',
-              'transition-colors',
-              'hover:bg-primary-600 disabled:hover:bg-primary-500',
-              'disabled:cursor-not-allowed disabled:opacity-50',
-            ].join(' ')}
           >
             {/* DOCX 아이콘 */}
             <span className="bg-primary-400/15 flex h-9 w-9 items-center justify-center rounded-[12px]">
@@ -103,7 +98,7 @@ const ComplaintDownloadSection: React.FC<ComplaintDownloadSectionProps> = ({ com
             </span>
 
             {isDownloading ? '다운로드 준비 중...' : 'DOCX 파일 다운로드'}
-          </button>
+          </Button>
 
           <p className="text-detail-regular text-neutral-500">
             * 브라우저의 팝업 차단 설정에 따라 다운로드 창이 보이지 않을 수 있어요.

--- a/src/sections/ComplaintInfoSection.tsx
+++ b/src/sections/ComplaintInfoSection.tsx
@@ -3,6 +3,7 @@ import DaumPostcodeButton from '@/components/DaumPostcodeButton';
 import type { DaumPostcodeResult } from '@/components/DaumPostcodeButton';
 import FormErrorMessage from '@/components/FormErrorMessage';
 import IntroHeader from '@/components/IntroHeader';
+import Button from '@/components/common/Button';
 import { splitAddressTo3FromString, splitPhoneKR } from '@/utils/krContact';
 import type { AxiosError } from 'axios';
 import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
@@ -188,18 +189,14 @@ const ComplainantInfoSection = forwardRef<ComplainantInfoSectionHandle, Props>(
           className="mt-2 flex w-[420px] flex-col gap-5"
         >
           {/* 내 정보 불러오기 버튼 */}
-          <div className="flex w-full justify-end">
-            <button
-              type="button"
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
               onClick={handleLoadFromProfile}
-              className={[
-                'rounded-200 inline-flex items-center border px-3 py-[8px]',
-                'border-primary-400 bg-primary-0/50 hover:bg-primary-50/50',
-                'text-detail-regular text-neutral-800',
-              ].join(' ')}
             >
               내 정보 불러오기
-            </button>
+            </Button>
           </div>
 
           {/* 입력 필드들 */}

--- a/src/sections/CrimeTypeSection.tsx
+++ b/src/sections/CrimeTypeSection.tsx
@@ -1,4 +1,5 @@
 import IntroHeader from '@/components/IntroHeader';
+import Button from '@/components/common/Button';
 import type { CrimeCategory, CrimeDomain } from '@/constants/crimeTypes';
 import { CRIME_TYPES } from '@/constants/crimeTypes';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -46,19 +47,15 @@ const CrimeTypeSection: React.FC = () => {
           {CRIME_TYPES.map((domain) => {
             const isActive = domain.id === domainId;
             return (
-              <button
+              <Button
                 key={domain.id}
-                type="button"
+                variant={isActive ? 'primary' : 'secondary'}
+                size="md"
                 onClick={() => setDomainId(domain.id)}
-                className={[
-                  'text-body-3 rounded-400 flex min-w-[120px] items-center justify-center px-4 py-2 transition-colors',
-                  isActive
-                    ? 'bg-primary-400 text-neutral-0'
-                    : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200',
-                ].join(' ')}
+                className="min-w-[120px]"
               >
                 {domain.name}
-              </button>
+              </Button>
             );
           })}
         </div>


### PR DESCRIPTION
### ✅ PR 설명

기존에 버튼이 여기저기서 정말 많이 사용됐는데, 이를 컴포넌트화 해두지 않았어서 중복 코드가 너무 많은 문제가 있었습니당 ..
그래서 하나의 컴포넌트로 분리해둔 후, `메인 컬러 버튼(primary)`, `회색 버튼(secondary)`, `빨간색 버튼(error)`, `테두리가 파란색인 버튼(outline)`, `테두리가 회색인 버튼(outline-secondary)` 스타일들을 정의해두었습니당.

### 🏗 작업 내용

- [x] 버튼 컴포넌트 추가
- [x] 기존 코드에서 버튼이 있는 부분들을 모두 버튼 컴포넌트로 교체

### 📸 테스트 결과 (선택)

> 

### 🔗 관련 이슈 (선택)

> 

### 🚨 참고 사항 (선택)

> 
