### PR TITLE
[Design] 로그인 / 약관 / 회원가입 페이지 디자인 변경

### DIFF
--- a/src/features/auth/components/AgreementDetailModal.tsx
+++ b/src/features/auth/components/AgreementDetailModal.tsx
@@ -1,9 +1,9 @@
+import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 
 import React from 'react';
-import { createPortal } from 'react-dom';
 
 type Props = {
   open: boolean;
@@ -83,7 +83,7 @@ const AgreementDetailModal: React.FC<Props> = ({
               setTimeout(onClose, 400);
             }}
             className={[
-              'flex w-full items-center justify-center gap-2 rounded-300 py-2.5',
+              'rounded-300 flex w-full items-center justify-center gap-2 py-2.5',
               'transition-all duration-200',
               checked
                 ? 'bg-primary-0 text-primary-400'
@@ -98,9 +98,7 @@ const AgreementDetailModal: React.FC<Props> = ({
             >
               {checked ? 'check_circle' : 'radio_button_unchecked'}
             </span>
-            <span className="text-body-3-bold">
-              {baseTitle}에 동의합니다
-            </span>
+            <span className="text-body-3-bold">{baseTitle}에 동의합니다</span>
           </button>
         </footer>
       </div>

--- a/src/features/auth/components/AgreementDetailModal.tsx
+++ b/src/features/auth/components/AgreementDetailModal.tsx
@@ -3,6 +3,7 @@ import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 
 import React from 'react';
+import { createPortal } from 'react-dom';
 
 type Props = {
   open: boolean;
@@ -25,23 +26,26 @@ const AgreementDetailModal: React.FC<Props> = ({
 
   const baseTitle = title.replace(/\(\)/, '');
 
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4"
+      className="fixed inset-0 z-50 flex items-center justify-center px-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="agreement-modal-title"
-      onClick={onClose}
     >
+      {/* 배경 오버레이 (클릭 시 닫힘) */}
+      <div
+        className="fixed inset-0 bg-neutral-900/40"
+        onClick={onClose}
+      />
       <div
         className={[
-          'flex flex-col',
+          'relative flex flex-col',
           'max-h-[70vh] w-full max-w-md',
           'rounded-[16px] bg-white',
           'shadow-[0_8px_30px_rgba(0,0,0,0.12)]',
           'overflow-hidden',
         ].join(' ')}
-        onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}
         <header className="flex items-center justify-between px-6 py-2">
@@ -100,7 +104,8 @@ const AgreementDetailModal: React.FC<Props> = ({
           </button>
         </footer>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/src/features/auth/components/AgreementDetailModal.tsx
+++ b/src/features/auth/components/AgreementDetailModal.tsx
@@ -27,49 +27,41 @@ const AgreementDetailModal: React.FC<Props> = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="agreement-modal-title"
+      onClick={onClose}
     >
       <div
         className={[
           'flex flex-col',
-          'max-h-[60vh] w-full max-w-md',
-          'bg-neutral-0 rounded-200 shadow-lg',
+          'max-h-[70vh] w-full max-w-md',
+          'rounded-[16px] bg-white',
+          'shadow-[0_8px_30px_rgba(0,0,0,0.12)]',
           'overflow-hidden',
         ].join(' ')}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}
-        <header
-          className={[
-            'flex items-center justify-between',
-            'border-b border-neutral-200',
-            'bg-primary-0/50',
-            'px-5 py-3',
-          ].join(' ')}
-        >
+        <header className="flex items-center justify-between px-6 py-4">
           <h2
             id="agreement-modal-title"
-            className="text-body-3-bold text-neutral-900"
+            className="text-body-2-bold text-neutral-900"
           >
             {title}
           </h2>
           <button
             type="button"
             onClick={onClose}
-            className={[
-              'rounded-400 border border-neutral-300',
-              'px-3 py-1.5',
-              'text-detail-regular text-neutral-800',
-              'bg-neutral-0 hover:bg-warning-0',
-            ].join(' ')}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
           >
-            닫기
+            <span className="material-symbols-outlined !text-[20px]">close</span>
           </button>
         </header>
+
         {/* 본문 */}
-        <div className="prose prose-slate prose-sm max-w-none overflow-y-auto p-6">
+        <div className="balaw-scrollbar prose prose-slate prose-sm max-w-none overflow-y-auto border-t border-neutral-100 px-6 py-5">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeSanitize]}
@@ -77,29 +69,35 @@ const AgreementDetailModal: React.FC<Props> = ({
             {content}
           </ReactMarkdown>
         </div>
+
         {/* 푸터 */}
-        <footer
-          className={[
-            'flex items-center justify-end gap-4',
-            'border-t border-neutral-200',
-            'bg-primary-0/50',
-            'px-5 py-3',
-          ].join(' ')}
-        >
-          <label className="flex cursor-pointer items-center gap-2">
-            <span className="text-body-3-regular text-neutral-900">
-              BaLaw {baseTitle}에 동의합니다.
+        <footer className="border-t border-neutral-100 px-6 py-4">
+          <button
+            type="button"
+            onClick={() => {
+              onToggleCheck();
+              onClose();
+            }}
+            className={[
+              'flex w-full items-center justify-center gap-2 rounded-300 py-2.5',
+              'transition-all duration-200',
+              checked
+                ? 'bg-primary-0 text-primary-400'
+                : 'bg-neutral-50 text-neutral-500 hover:bg-neutral-100',
+            ].join(' ')}
+          >
+            <span
+              className={[
+                'material-symbols-outlined !text-[20px] transition-colors duration-200',
+                checked ? 'text-primary-400' : 'text-neutral-400',
+              ].join(' ')}
+            >
+              {checked ? 'check_circle' : 'radio_button_unchecked'}
             </span>
-            <input
-              type="checkbox"
-              checked={checked}
-              onChange={() => {
-                onToggleCheck();
-                onClose();
-              }}
-              className="accent-positive-200 h-4 w-4 cursor-pointer"
-            />
-          </label>
+            <span className="text-body-3-bold">
+              {baseTitle}에 동의합니다
+            </span>
+          </button>
         </footer>
       </div>
     </div>

--- a/src/features/auth/components/AgreementDetailModal.tsx
+++ b/src/features/auth/components/AgreementDetailModal.tsx
@@ -44,19 +44,19 @@ const AgreementDetailModal: React.FC<Props> = ({
         onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}
-        <header className="flex items-center justify-between px-6 py-4">
+        <header className="flex items-center justify-between px-6 py-2">
           <h2
             id="agreement-modal-title"
-            className="text-body-2-bold text-neutral-900"
+            className="text-body-3-bold text-neutral-900"
           >
             {title}
           </h2>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
+            className="flex h-6 w-6 items-center justify-center rounded-full text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
           >
-            <span className="material-symbols-outlined !text-[20px]">close</span>
+            <span className="material-symbols-outlined !text-[16px]">close</span>
           </button>
         </header>
 
@@ -76,7 +76,7 @@ const AgreementDetailModal: React.FC<Props> = ({
             type="button"
             onClick={() => {
               onToggleCheck();
-              onClose();
+              setTimeout(onClose, 400);
             }}
             className={[
               'flex w-full items-center justify-center gap-2 rounded-300 py-2.5',

--- a/src/features/auth/components/AgreementItem.tsx
+++ b/src/features/auth/components/AgreementItem.tsx
@@ -12,52 +12,45 @@ const AgreementItem: React.FC<Props> = ({ data, onToggleCheck }) => {
   const { id, title, content, isChecked, required } = data;
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const labelText = required ? '(필수)' : '(선택)';
-
   return (
     <>
-      {/* 왼쪽 텍스트, 오른쪽 체크박스 */}
-      <div
-        className={[
-          'flex items-center justify-between gap-4',
-          'rounded-100 bg-neutral-0 border border-neutral-200',
-          'px-4 py-3',
-        ].join(' ')}
-      >
-        <div className="flex items-center gap-2">
-          {/* 필수 or 선택 뱃지 */}
-          <span
-            className={
-              required ? 'text-body-3-bold text-positive-200' : 'text-body-3-bold text-neutral-500'
-            }
+      <div className="flex items-center justify-between py-2.5">
+        {/* 좌측: 체크 아이콘 + 제목 */}
+        <div className="flex items-center gap-2.5">
+          <button
+            type="button"
+            onClick={() => onToggleCheck(id)}
+            className="flex-shrink-0"
           >
-            {labelText}
-          </span>
+            <span
+              className={[
+                'material-symbols-outlined !text-[22px] transition-colors duration-200',
+                isChecked ? 'text-primary-400' : 'text-neutral-300',
+              ].join(' ')}
+            >
+              {isChecked ? 'check_circle' : 'radio_button_unchecked'}
+            </span>
+          </button>
 
-          {/* 제목 및 > 아이콘 */}
           <button
             type="button"
             onClick={() => setIsOpen(true)}
-            className="flex items-center gap-2"
+            className="flex items-center gap-1 text-left"
           >
-            <span className="text-body-1-regular text-neutral-900">{title}</span>
             <span
-              className="material-symbols-outlined text-neutral-400"
-              style={{ fontSize: '12px' }}
+              className={[
+                'text-detail-bold',
+                required ? 'text-primary-400' : 'text-neutral-400',
+              ].join(' ')}
             >
-              arrow_forward_ios
+              {required ? '[필수]' : '[선택]'}
+            </span>
+            <span className="text-body-3-regular text-neutral-700">{title}</span>
+            <span className="material-symbols-outlined !text-[14px] text-neutral-400">
+              chevron_right
             </span>
           </button>
         </div>
-
-        {/* 오른쪽 체크박스 */}
-        <input
-          type="checkbox"
-          checked={isChecked}
-          onChange={() => onToggleCheck(id)}
-          className="accent-positive-200 h-5 w-5 cursor-pointer"
-          aria-required={required}
-        />
       </div>
 
       {/* 약관 자세히 보기 모달 */}

--- a/src/features/auth/components/AgreementItem.tsx
+++ b/src/features/auth/components/AgreementItem.tsx
@@ -20,11 +20,11 @@ const AgreementItem: React.FC<Props> = ({ data, onToggleCheck }) => {
           <button
             type="button"
             onClick={() => onToggleCheck(id)}
-            className="flex-shrink-0"
+            className="flex flex-shrink-0 items-center"
           >
             <span
               className={[
-                'material-symbols-outlined !text-[22px] transition-colors duration-200',
+                'material-symbols-outlined !text-[20px] leading-none transition-colors duration-200',
                 isChecked ? 'text-primary-400' : 'text-neutral-300',
               ].join(' ')}
             >
@@ -35,18 +35,18 @@ const AgreementItem: React.FC<Props> = ({ data, onToggleCheck }) => {
           <button
             type="button"
             onClick={() => setIsOpen(true)}
-            className="flex items-center gap-1 text-left"
+            className="flex items-center gap-1"
           >
             <span
               className={[
-                'text-detail-bold',
+                'text-detail-bold leading-none',
                 required ? 'text-primary-400' : 'text-neutral-400',
               ].join(' ')}
             >
               {required ? '[필수]' : '[선택]'}
             </span>
-            <span className="text-body-3-regular text-neutral-700">{title}</span>
-            <span className="material-symbols-outlined !text-[14px] text-neutral-400">
+            <span className="text-detail-regular leading-none text-neutral-700">{title}</span>
+            <span className="material-symbols-outlined !text-[14px] leading-none text-neutral-400">
               chevron_right
             </span>
           </button>

--- a/src/features/auth/components/AgreementsCard.tsx
+++ b/src/features/auth/components/AgreementsCard.tsx
@@ -2,8 +2,10 @@ import { useNavigate } from 'react-router-dom';
 
 import React, { useMemo, useState } from 'react';
 
+import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import Button from '@/shared/ui/common/Button';
 
+import AuthCard from '@/features/auth/components/AuthCard';
 import type { Agreement } from '@/features/auth/types/model';
 
 import AgreementItem from './AgreementItem';
@@ -19,24 +21,19 @@ const AgreementsCard: React.FC<Props> = ({ initial }) => {
   const [touched, setTouched] = useState(false);
   const navigate = useNavigate();
 
-  // 모든 필수 항목에 체크했는지 검증
   const requiredAllChecked = useMemo(
     () => items.every((a) => (a.required ? a.isChecked : true)),
     [items],
   );
 
-  // 전체 항목이 모두 체크되었는지 계산 (선택도 포함해서 계산함) <- 전체동의 체크박스에 써야 돼서
   const allChecked = useMemo(() => items.every((a) => a.isChecked), [items]);
 
-  // 전체 동의 토글 (모든 항목의 isChecked를 일괄 변경함)
   const toggleAll = (next: boolean) =>
     setItems((prev) => prev.map((a) => ({ ...a, isChecked: next })));
 
-  // 단일 항목 토글
   const toggleCheck = (id: number) =>
     setItems((prev) => prev.map((a) => (a.id === id ? { ...a, isChecked: !a.isChecked } : a)));
 
-  // 제출을 위한 핸들러
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setTouched(true);
@@ -45,52 +42,39 @@ const AgreementsCard: React.FC<Props> = ({ initial }) => {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className={[
-        'rounded-300 border-primary-400 border',
-        'px-8 py-10',
-        'h-full',
-        'flex flex-col',
-      ].join(' ')}
-    >
-      {/* 제목 */}
-      <h2 className="text-heading-1-bold text-primary-400 text-center">BaLaw 이용 약관</h2>
+    <AuthCard as="form" onSubmit={handleSubmit} className="gap-5">
+      {/* 전체 동의 */}
+      <button
+        type="button"
+        onClick={() => toggleAll(!allChecked)}
+        className="flex items-center gap-2.5 rounded-300 bg-neutral-50 px-4 py-3"
+      >
+        <span
+          className={[
+            'material-symbols-outlined !text-[22px] transition-colors duration-200',
+            allChecked ? 'text-primary-400' : 'text-neutral-300',
+          ].join(' ')}
+        >
+          {allChecked ? 'check_circle' : 'radio_button_unchecked'}
+        </span>
+        <span className="text-body-3-bold text-neutral-900">전체 동의</span>
+      </button>
 
       {/* 약관 목록 */}
-      <div className="mt-15 flex flex-1 flex-col justify-center">
-        <div className="space-y-6">
-          {items.map((ag) => (
-            <AgreementItem
-              key={ag.id}
-              data={ag}
-              onToggleCheck={toggleCheck}
-            />
-          ))}
-        </div>
-
-        <label className="text-body-3-regular mt-6 flex cursor-pointer items-center justify-end gap-2">
-          <input
-            type="checkbox"
-            checked={allChecked}
-            onChange={(e) => toggleAll(e.target.checked)}
-            className="accent-primary-400 h-4 w-4 cursor-pointer"
+      <div className="flex flex-col divide-y divide-neutral-100 px-4">
+        {items.map((ag) => (
+          <AgreementItem
+            key={ag.id}
+            data={ag}
+            onToggleCheck={toggleCheck}
           />
-          <span className="text-neutral-900">전체 동의</span>
-        </label>
+        ))}
       </div>
 
       {/* 경고 문구 */}
-      <div
-        aria-live="polite"
-        className="mb-4 flex min-h-[24px] justify-center"
-      >
-        {!requiredAllChecked && touched && (
-          <p className="text-body-3-regular text-warning-200">
-            모든 필수 항목에 동의해야 서비스를 이용할 수 있어요.
-          </p>
-        )}
-      </div>
+      {!requiredAllChecked && touched && (
+        <FormErrorMessage error="모든 필수 항목에 동의해야 서비스를 이용할 수 있어요." />
+      )}
 
       {/* 버튼 */}
       <Button
@@ -99,11 +83,10 @@ const AgreementsCard: React.FC<Props> = ({ initial }) => {
         fullWidth
         type="submit"
         disabled={!requiredAllChecked}
-        aria-disabled={!requiredAllChecked}
       >
         회원가입 진행하기
       </Button>
-    </form>
+    </AuthCard>
   );
 };
 

--- a/src/features/auth/components/AgreementsCard.tsx
+++ b/src/features/auth/components/AgreementsCard.tsx
@@ -42,12 +42,16 @@ const AgreementsCard: React.FC<Props> = ({ initial }) => {
   };
 
   return (
-    <AuthCard as="form" onSubmit={handleSubmit} className="gap-5">
+    <AuthCard
+      as="form"
+      onSubmit={handleSubmit}
+      className="gap-5"
+    >
       {/* 전체 동의 */}
       <button
         type="button"
         onClick={() => toggleAll(!allChecked)}
-        className="flex items-center gap-2.5 rounded-300 bg-neutral-50 px-4 py-3"
+        className="rounded-300 flex items-center gap-2.5 bg-neutral-50 px-4 py-3"
       >
         <span
           className={[

--- a/src/features/auth/components/AuthCard.tsx
+++ b/src/features/auth/components/AuthCard.tsx
@@ -15,7 +15,7 @@ const AuthCard: React.FC<AuthCardProps> = ({ children, as = 'div', onSubmit, cla
       onSubmit={onSubmit}
       className={[
         'w-full rounded-[16px]',
-        'bg-gradient-to-b from-primary-0/40 via-white to-white',
+        'from-primary-0/40 bg-gradient-to-b via-white to-white',
         'border border-neutral-100',
         'shadow-[0_4px_24px_rgba(0,0,0,0.06)]',
         'px-8 py-8',

--- a/src/features/auth/components/AuthCard.tsx
+++ b/src/features/auth/components/AuthCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface AuthCardProps {
+  children: React.ReactNode;
+  as?: 'div' | 'form';
+  onSubmit?: (e: React.FormEvent) => void;
+  className?: string;
+}
+
+const AuthCard: React.FC<AuthCardProps> = ({ children, as = 'div', onSubmit, className = '' }) => {
+  const Tag = as;
+
+  return (
+    <Tag
+      onSubmit={onSubmit}
+      className={[
+        'w-full rounded-[16px]',
+        'bg-gradient-to-b from-primary-0/40 via-white to-white',
+        'border border-neutral-100',
+        'shadow-[0_4px_24px_rgba(0,0,0,0.06)]',
+        'px-8 py-8',
+        'flex flex-col',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </Tag>
+  );
+};
+
+export default AuthCard;

--- a/src/features/auth/components/LoginCard.tsx
+++ b/src/features/auth/components/LoginCard.tsx
@@ -5,7 +5,6 @@ import Button from '@/shared/ui/common/Button';
 import Input from '@/shared/ui/common/Input';
 
 import AuthCard from '@/features/auth/components/AuthCard';
-
 import type { LoginFormValues } from '@/features/auth/types/form';
 import { mapAuthError } from '@/features/auth/utils/mapAuthError';
 
@@ -51,9 +50,7 @@ const LoginCard: React.FC<LoginCardProps> = ({ className = '', onLogin }) => {
       <form className="flex flex-col gap-4">
         {/* 이메일 */}
         <div className="flex items-center gap-3">
-          <span className="material-symbols-outlined !text-[22px] text-neutral-400">
-            mail
-          </span>
+          <span className="material-symbols-outlined !text-[22px] text-neutral-400">mail</span>
           <Input
             id="email"
             type="email"
@@ -72,9 +69,7 @@ const LoginCard: React.FC<LoginCardProps> = ({ className = '', onLogin }) => {
 
         {/* 비밀번호 */}
         <div className="flex items-center gap-3">
-          <span className="material-symbols-outlined !text-[22px] text-neutral-400">
-            lock
-          </span>
+          <span className="material-symbols-outlined !text-[22px] text-neutral-400">lock</span>
           <Input
             id="password"
             type="password"

--- a/src/features/auth/components/LoginCard.tsx
+++ b/src/features/auth/components/LoginCard.tsx
@@ -4,6 +4,8 @@ import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import Button from '@/shared/ui/common/Button';
 import Input from '@/shared/ui/common/Input';
 
+import AuthCard from '@/features/auth/components/AuthCard';
+
 import type { LoginFormValues } from '@/features/auth/types/form';
 import { mapAuthError } from '@/features/auth/utils/mapAuthError';
 
@@ -45,76 +47,52 @@ const LoginCard: React.FC<LoginCardProps> = ({ className = '', onLogin }) => {
   };
 
   return (
-    <section
-      className={[
-        'rounded-300 border-primary-400 border',
-        'px-8 py-10',
-        'h-full',
-        'flex flex-col',
-        className,
-      ].join(' ')}
-    >
-      <h2 className="text-heading-1-bold text-primary-400 text-center">로그인</h2>
-
-      <form className="mt-15 flex flex-1 flex-col justify-center gap-6 px-5">
+    <AuthCard className={`gap-6 ${className}`}>
+      <form className="flex flex-col gap-4">
         {/* 이메일 */}
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-4">
-            {/* 이메일 아이콘 */}
-            <span
-              className="material-symbols-outlined text-primary-600/50"
-              style={{ fontSize: '24px' }}
-            >
-              mail
-            </span>
-
-            {/* 이메일 입력칸 */}
-            <Input
-              id="email"
-              type="email"
-              autoComplete="email"
-              required
-              fullWidth
-              textAlign="left"
-              placeholder="이메일 주소"
-              value={values.email}
-              onChange={(e) => setValues((prev) => ({ ...prev, email: e.target.value }))}
-              disabled={loading}
-              onKeyDown={blockEnterInInput}
-            />
-          </div>
+        <div className="flex items-center gap-3">
+          <span className="material-symbols-outlined !text-[22px] text-neutral-400">
+            mail
+          </span>
+          <Input
+            id="email"
+            type="email"
+            autoComplete="email"
+            required
+            fullWidth
+            textAlign="left"
+            placeholder="이메일 주소"
+            className="text-detail-regular"
+            value={values.email}
+            onChange={(e) => setValues((prev) => ({ ...prev, email: e.target.value }))}
+            disabled={loading}
+            onKeyDown={blockEnterInInput}
+          />
         </div>
 
         {/* 비밀번호 */}
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-4">
-            {/* 비밀번호 아이콘 */}
-            <span
-              className="material-symbols-outlined text-primary-600/50"
-              style={{ fontSize: '24px' }}
-            >
-              lock
-            </span>
-
-            {/* 비밀번호 입력칸 */}
-            <Input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              required
-              fullWidth
-              textAlign="left"
-              placeholder="비밀번호"
-              value={values.password}
-              onChange={(e) => setValues((prev) => ({ ...prev, password: e.target.value }))}
-              disabled={loading}
-              onKeyDown={blockEnterInInput}
-            />
-          </div>
+        <div className="flex items-center gap-3">
+          <span className="material-symbols-outlined !text-[22px] text-neutral-400">
+            lock
+          </span>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            fullWidth
+            textAlign="left"
+            placeholder="비밀번호"
+            className="text-detail-regular"
+            value={values.password}
+            onChange={(e) => setValues((prev) => ({ ...prev, password: e.target.value }))}
+            disabled={loading}
+            onKeyDown={blockEnterInInput}
+          />
         </div>
       </form>
 
-      {/* 경고 문구 */}
+      {/* 에러 메시지 */}
       <FormErrorMessage error={error} />
 
       {/* 로그인 버튼 */}
@@ -130,16 +108,16 @@ const LoginCard: React.FC<LoginCardProps> = ({ className = '', onLogin }) => {
       </Button>
 
       {/* 회원가입 안내 */}
-      <div className="mt-10 flex flex-col items-center gap-2">
-        <p className="text-body-3-regular text-primary-400">아직 회원이 아니신가요?</p>
+      <div className="flex items-center justify-center gap-1.5">
+        <p className="text-detail-regular text-neutral-400">아직 회원이 아니신가요?</p>
         <a
           href={SIGNUP_HREF}
-          className="text-body-3-bold hover:text-primary-600 text-neutral-700 underline underline-offset-4"
+          className="text-detail-bold text-primary-400 hover:text-primary-500"
         >
-          회원가입 하러 가기
+          회원가입
         </a>
       </div>
-    </section>
+    </AuthCard>
   );
 };
 

--- a/src/features/auth/components/SignupAccountCard.tsx
+++ b/src/features/auth/components/SignupAccountCard.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import Button from '@/shared/ui/common/Button';
 
+import AuthCard from '@/features/auth/components/AuthCard';
 import { checkEmailAvailability } from '@/features/auth/apis/auth';
 import { mapAuthError } from '@/features/auth/utils/mapAuthError';
 
@@ -115,20 +116,10 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
   const isNextDisabled = !email || !pw || !pwCheck || emailCheckStatus !== 'success';
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className={[
-        'rounded-300 border-primary-400 border',
-        'px-8 py-10',
-        'h-full',
-        'flex flex-col',
-      ].join(' ')}
-    >
-      {/* 제목 */}
-      <h2 className="text-heading-1-bold text-primary-400 text-center">회원가입</h2>
+    <AuthCard as="form" onSubmit={handleSubmit} className="gap-6">
 
       {/* 입력 폼 */}
-      <div className="mt-15 flex flex-1 flex-col justify-center gap-6 px-5">
+      <div className="flex flex-col gap-5">
         {/* 이메일 */}
         <div className="flex flex-col gap-2">
           {renderLabel('이메일', true)}
@@ -144,7 +135,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
                 id="email"
                 type="email"
                 className={[
-                  'rounded-200 h-12 flex-1 px-3',
+                  'rounded-200 h-8 flex-1 px-3',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -160,7 +151,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
               {/* 중복 확인 버튼 */}
               <Button
                 variant="secondary"
-                size="md"
+                size="sm"
                 disabled={emailCheckStatus !== 'idle'}
                 onClick={handleEmailCheck}
               >
@@ -189,7 +180,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
                 id="password"
                 type={showPw ? 'text' : 'password'}
                 className={[
-                  'rounded-200 h-12 w-full px-3 pr-10',
+                  'rounded-200 h-8 w-full px-3 pr-10',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -231,7 +222,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
                 id="password2"
                 type={showPwCheck ? 'text' : 'password'}
                 className={[
-                  'rounded-200 h-12 w-full px-3 pr-10',
+                  'rounded-200 h-8 w-full px-3 pr-10',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -272,7 +263,7 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
       >
         다음
       </Button>
-    </form>
+    </AuthCard>
   );
 };
 

--- a/src/features/auth/components/SignupAccountCard.tsx
+++ b/src/features/auth/components/SignupAccountCard.tsx
@@ -3,8 +3,8 @@ import React, { useState } from 'react';
 import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import Button from '@/shared/ui/common/Button';
 
-import AuthCard from '@/features/auth/components/AuthCard';
 import { checkEmailAvailability } from '@/features/auth/apis/auth';
+import AuthCard from '@/features/auth/components/AuthCard';
 import { mapAuthError } from '@/features/auth/utils/mapAuthError';
 
 type Props = {
@@ -116,8 +116,11 @@ const SignupAccountCard: React.FC<Props> = ({ defaultValues, onNext }) => {
   const isNextDisabled = !email || !pw || !pwCheck || emailCheckStatus !== 'success';
 
   return (
-    <AuthCard as="form" onSubmit={handleSubmit} className="gap-6">
-
+    <AuthCard
+      as="form"
+      onSubmit={handleSubmit}
+      className="gap-6"
+    >
       {/* 입력 폼 */}
       <div className="flex flex-col gap-5">
         {/* 이메일 */}

--- a/src/features/auth/components/SignupCard.tsx
+++ b/src/features/auth/components/SignupCard.tsx
@@ -88,7 +88,10 @@ const SignupCard: React.FC<SignupCardProps> = ({ onSignup }) => {
 
   return (
     <div className="w-full max-w-[460px]">
-      <div key={step} className="animate-fade-in">
+      <div
+        key={step}
+        className="animate-fade-in"
+      >
         {step === 1 ? (
           <SignupAccountCard
             defaultValues={formData}

--- a/src/features/auth/components/SignupCard.tsx
+++ b/src/features/auth/components/SignupCard.tsx
@@ -87,21 +87,21 @@ const SignupCard: React.FC<SignupCardProps> = ({ onSignup }) => {
   };
 
   return (
-    <div className="h-full w-full max-w-[460px]">
-      {step === 1 ? (
-        // 1단계: 계정 정보 입력 (이메일, 비밀번호)
-        <SignupAccountCard
-          defaultValues={formData}
-          onNext={handleAccountNext}
-        />
-      ) : (
-        // 2단계: 프로필 정보 입력 (이름, 주소, 전화번호)
-        <SignupProfileCard
-          defaultValues={formData}
-          onBack={handleProfileBack}
-          onNext={handleProfileNext}
-        />
-      )}
+    <div className="w-full max-w-[460px]">
+      <div key={step} className="animate-fade-in">
+        {step === 1 ? (
+          <SignupAccountCard
+            defaultValues={formData}
+            onNext={handleAccountNext}
+          />
+        ) : (
+          <SignupProfileCard
+            defaultValues={formData}
+            onBack={handleProfileBack}
+            onNext={handleProfileNext}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/features/auth/components/SignupProfileCard.tsx
+++ b/src/features/auth/components/SignupProfileCard.tsx
@@ -98,7 +98,11 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
   };
 
   return (
-    <AuthCard as="form" onSubmit={handleSubmit} className="gap-6">
+    <AuthCard
+      as="form"
+      onSubmit={handleSubmit}
+      className="gap-6"
+    >
       {/* 제목 + 이전 버튼 */}
       <div className="relative flex items-center justify-center">
         <button

--- a/src/features/auth/components/SignupProfileCard.tsx
+++ b/src/features/auth/components/SignupProfileCard.tsx
@@ -4,6 +4,8 @@ import DaumPostcodeButton from '@/shared/ui/DaumPostcodeButton';
 import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import Button from '@/shared/ui/common/Button';
 
+import AuthCard from '@/features/auth/components/AuthCard';
+
 type SignupProfileData = {
   name: string;
   city: string;
@@ -96,15 +98,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className={[
-        'rounded-300 border-primary-400 border',
-        'px-8 py-10',
-        'h-full',
-        'flex flex-col',
-      ].join(' ')}
-    >
+    <AuthCard as="form" onSubmit={handleSubmit} className="gap-6">
       {/* 제목 + 이전 버튼 */}
       <div className="relative flex items-center justify-center">
         <button
@@ -141,7 +135,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
               placeholder="홍길동"
               type="name"
               className={[
-                'rounded-200 w- h-12 flex-1 px-3',
+                'rounded-200 w- h-8 flex-1 px-3',
                 'border border-neutral-300',
                 'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
               ].join(' ')}
@@ -182,7 +176,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 onClick={handleAddressFieldClick}
                 onFocus={handleAddressFieldClick}
                 className={[
-                  'rounded-200 w- h-12 flex-1 px-3 text-center',
+                  'rounded-200 w- h-8 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   hasAddress ? 'bg-neutral-0' : 'cursor-not-allowed bg-neutral-50',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
@@ -197,7 +191,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 onClick={handleAddressFieldClick}
                 onFocus={handleAddressFieldClick}
                 className={[
-                  'rounded-200 w- h-12 flex-1 px-3 text-center',
+                  'rounded-200 w- h-8 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   hasAddress ? 'bg-neutral-0' : 'cursor-not-allowed bg-neutral-50',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
@@ -212,7 +206,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 onClick={handleAddressFieldClick}
                 onFocus={handleAddressFieldClick}
                 className={[
-                  'rounded-200 w- h-12 flex-1 px-3 text-center',
+                  'rounded-200 w- h-8 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   hasAddress ? 'bg-neutral-0' : 'cursor-not-allowed bg-neutral-50',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
@@ -246,7 +240,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 value={phone1}
                 onChange={(e) => setPhone1(e.target.value)}
                 className={[
-                  'rounded-200 w- h-12 flex-1 px-3 text-center',
+                  'rounded-200 w- h-8 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -259,7 +253,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 value={phone2}
                 onChange={(e) => setPhone2(e.target.value)}
                 className={[
-                  'rounded-200 w- h-12 flex-1 px-3 text-center',
+                  'rounded-200 w- h-8 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -272,7 +266,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
                 value={phone3}
                 onChange={(e) => setPhone3(e.target.value)}
                 className={[
-                  'rounded-200 w- h-12 flex-1 px-3 text-center',
+                  'rounded-200 w- h-8 flex-1 px-3 text-center',
                   'border border-neutral-300',
                   'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
                 ].join(' ')}
@@ -295,7 +289,7 @@ const SignupProfileCard: React.FC<Props> = ({ defaultValues, onBack, onNext }) =
       >
         {isSubmitting ? '회원가입 진행중...' : '회원가입'}
       </Button>
-    </form>
+    </AuthCard>
   );
 };
 

--- a/src/features/auth/pages/AgreementPage.tsx
+++ b/src/features/auth/pages/AgreementPage.tsx
@@ -1,38 +1,36 @@
 import React from 'react';
 
-import useIsMdUp from '@/shared/hooks/useIsMdUp';
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
 import Footer from '@/shared/ui/Footer';
 import Header from '@/shared/ui/Header';
+import SectionHeader from '@/shared/ui/SectionHeader';
 
 import AgreementsCard from '@/features/auth/components/AgreementsCard';
-import WelcomeCard from '@/features/auth/components/WelcomeCard';
 import { DEFAULT_AGREEMENTS } from '@/features/auth/constants/agreement';
 
 const AgreementsPage: React.FC = () => {
-  const isMdUp = useIsMdUp();
-
   return (
-    <div className="bg-neutral-0 flex min-h-screen flex-col">
+    <div className="flex h-screen flex-col overflow-hidden bg-neutral-50">
       <Header />
+      <main className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
+        <div className="flex w-full max-w-[420px] flex-col items-center">
+          {/* 캐릭터 + 인사말 */}
+          <img
+            src={characterUrl}
+            alt="BaLaw 캐릭터"
+            className="mb-4 h-24 w-24"
+            draggable={false}
+          />
+          <SectionHeader
+            size="sm"
+            title="시작하기 전에"
+            description="서비스 이용을 위한 약관에 동의해주세요."
+          />
 
-      <main className="flex flex-1 items-center">
-        <div className="mx-auto w-full max-w-[1000px] py-8 md:py-10">
-          <div className="flex flex-col items-center justify-center gap-8 md:flex-row">
-            {/* md 이상에서만 WelcomeCard 렌더 */}
-            {isMdUp && (
-              <div className="h-[600px] w-full max-w-[460px] flex-1">
-                <WelcomeCard variant="signup" />
-              </div>
-            )}
-
-            {/* 약관 카드는 항상 표시 */}
-            <div className="h-[600px] w-full max-w-[460px] flex-1">
-              <AgreementsCard initial={DEFAULT_AGREEMENTS} />
-            </div>
-          </div>
+          {/* 약관 카드 */}
+          <AgreementsCard initial={DEFAULT_AGREEMENTS} />
         </div>
       </main>
-
       <Footer />
     </div>
   );

--- a/src/features/auth/pages/AgreementPage.tsx
+++ b/src/features/auth/pages/AgreementPage.tsx
@@ -13,7 +13,7 @@ const AgreementsPage: React.FC = () => {
     <div className="flex h-screen flex-col overflow-hidden bg-neutral-50">
       <Header />
       <main className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
-        <div className="flex w-full max-w-[420px] flex-col items-center">
+        <div className="animate-fade-in flex w-full max-w-[420px] flex-col items-center">
           {/* 캐릭터 + 인사말 */}
           <img
             src={characterUrl}

--- a/src/features/auth/pages/AgreementPage.tsx
+++ b/src/features/auth/pages/AgreementPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import characterUrl from '@/assets/BaLawCharacter-large.svg';
+
 import Footer from '@/shared/ui/Footer';
 import Header from '@/shared/ui/Header';
 import SectionHeader from '@/shared/ui/SectionHeader';

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -2,17 +2,16 @@ import { useNavigate } from 'react-router-dom';
 
 import React from 'react';
 
-import useIsMdUp from '@/shared/hooks/useIsMdUp';
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
 import Footer from '@/shared/ui/Footer';
 import Header from '@/shared/ui/Header';
+import SectionHeader from '@/shared/ui/SectionHeader';
 
 import { login } from '@/features/auth/apis/auth';
 import LoginCard from '@/features/auth/components/LoginCard';
-import WelcomeCard from '@/features/auth/components/WelcomeCard';
 import type { LoginFormValues } from '@/features/auth/types/form';
 
 const LoginPage: React.FC = () => {
-  const isMdUp = useIsMdUp(); // md 이상일 때만 true
   const navigate = useNavigate();
 
   const handleLogin = async (values: LoginFormValues) => {
@@ -21,27 +20,27 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="bg-neutral-0 flex min-h-screen flex-col">
+    <div className="flex h-screen flex-col overflow-hidden bg-neutral-50">
       <Header />
+      <main className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
+        <div className="flex w-full max-w-[420px] flex-col items-center">
+          {/* 캐릭터 + 인사말 */}
+          <img
+            src={characterUrl}
+            alt="BaLaw 캐릭터"
+            className="mb-4 h-24 w-24"
+            draggable={false}
+          />
+          <SectionHeader
+            size="sm"
+            title="다시 만나서 반가워요!"
+            description="바로와 함께 시작해볼까요?"
+          />
 
-      <main className="flex flex-1 items-center">
-        <div className="mx-auto w-full max-w-[1000px] py-8 md:py-10">
-          <div className="flex flex-col items-center justify-center gap-8 md:flex-row">
-            {/* md 이상에서만 WelcomeCard 렌더 */}
-            {isMdUp && (
-              <div className="h-[600px] w-full max-w-[460px] flex-1">
-                <WelcomeCard variant="login" />
-              </div>
-            )}
-
-            {/* 로그인 카드는 항상 표시 */}
-            <div className="h-[600px] w-full max-w-[460px] flex-1">
-              <LoginCard onLogin={handleLogin} />
-            </div>
-          </div>
+          {/* 로그인 카드 */}
+          <LoginCard onLogin={handleLogin} />
         </div>
       </main>
-
       <Footer />
     </div>
   );

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import React from 'react';
 
 import characterUrl from '@/assets/BaLawCharacter-large.svg';
+
 import Footer from '@/shared/ui/Footer';
 import Header from '@/shared/ui/Header';
 import SectionHeader from '@/shared/ui/SectionHeader';

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -23,7 +23,7 @@ const LoginPage: React.FC = () => {
     <div className="flex h-screen flex-col overflow-hidden bg-neutral-50">
       <Header />
       <main className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
-        <div className="flex w-full max-w-[420px] flex-col items-center">
+        <div className="animate-fade-in flex w-full max-w-[420px] flex-col items-center">
           {/* 캐릭터 + 인사말 */}
           <img
             src={characterUrl}

--- a/src/features/auth/pages/SignupPage.tsx
+++ b/src/features/auth/pages/SignupPage.tsx
@@ -23,7 +23,7 @@ const SignupPage: React.FC = () => {
     <div className="flex h-screen flex-col overflow-hidden bg-neutral-50">
       <Header />
       <main className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
-        <div className="flex w-full max-w-[420px] flex-col items-center">
+        <div className="animate-fade-in flex w-full max-w-[420px] flex-col items-center">
           {/* 캐릭터 + 인사말 */}
           <img
             src={characterUrl}

--- a/src/features/auth/pages/SignupPage.tsx
+++ b/src/features/auth/pages/SignupPage.tsx
@@ -2,17 +2,16 @@ import { useNavigate } from 'react-router-dom';
 
 import React from 'react';
 
-import useIsMdUp from '@/shared/hooks/useIsMdUp';
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
 import Footer from '@/shared/ui/Footer';
 import Header from '@/shared/ui/Header';
+import SectionHeader from '@/shared/ui/SectionHeader';
 
 import { register } from '@/features/auth/apis/auth';
 import SignupCard from '@/features/auth/components/SignupCard';
-import WelcomeCard from '@/features/auth/components/WelcomeCard';
 import type { RegisterFormValues } from '@/features/auth/types/form';
 
 const SignupPage: React.FC = () => {
-  const isMdUp = useIsMdUp();
   const navigate = useNavigate();
 
   const handleSignup = async (values: RegisterFormValues) => {
@@ -21,27 +20,27 @@ const SignupPage: React.FC = () => {
   };
 
   return (
-    <div className="bg-neutral-0 flex min-h-screen flex-col">
+    <div className="flex h-screen flex-col overflow-hidden bg-neutral-50">
       <Header />
+      <main className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
+        <div className="flex w-full max-w-[420px] flex-col items-center">
+          {/* 캐릭터 + 인사말 */}
+          <img
+            src={characterUrl}
+            alt="BaLaw 캐릭터"
+            className="mb-4 h-24 w-24"
+            draggable={false}
+          />
+          <SectionHeader
+            size="sm"
+            title="바로에 오신 걸 환영해요!"
+            description="간단한 정보만 입력하면 바로 시작할 수 있어요."
+          />
 
-      <main className="flex flex-1 items-center">
-        <div className="mx-auto w-full max-w-[1000px] py-8 md:py-10">
-          <div className="flex flex-col items-center justify-center gap-8 md:flex-row">
-            {/* md 이상에서만 WelcomeCard 렌더 */}
-            {isMdUp && (
-              <div className="h-[600px] w-full max-w-[460px] flex-1">
-                <WelcomeCard variant="signup" />
-              </div>
-            )}
-
-            {/* 회원가입 카드 */}
-            <div className="h-[600px] w-full max-w-[460px] flex-1">
-              <SignupCard onSignup={handleSignup} />
-            </div>
-          </div>
+          {/* 회원가입 카드 */}
+          <SignupCard onSignup={handleSignup} />
         </div>
       </main>
-
       <Footer />
     </div>
   );

--- a/src/features/auth/pages/SignupPage.tsx
+++ b/src/features/auth/pages/SignupPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import React from 'react';
 
 import characterUrl from '@/assets/BaLawCharacter-large.svg';
+
 import Footer from '@/shared/ui/Footer';
 import Header from '@/shared/ui/Header';
 import SectionHeader from '@/shared/ui/SectionHeader';

--- a/src/shared/ui/FormErrorMessage.tsx
+++ b/src/shared/ui/FormErrorMessage.tsx
@@ -6,19 +6,22 @@ type FormErrorMessageProps = {
 };
 
 const FormErrorMessage: React.FC<FormErrorMessageProps> = ({ error, className = '' }) => {
+  if (!error) return null;
+
   return (
     <div
       aria-live="polite"
-      className={['mb-4 flex min-h-[24px] justify-center', className].join(' ')}
+      className={[
+        'flex items-center gap-2 rounded-300 bg-warning-0 px-4 py-3',
+        className,
+      ].join(' ')}
     >
-      {error && (
-        <p
-          className="text-body-3-regular text-warning-200 text-center"
-          role="alert"
-        >
-          {error}
-        </p>
-      )}
+      <span className="material-symbols-outlined flex-shrink-0 !text-[18px] text-warning-200">
+        error
+      </span>
+      <p className="text-detail-regular text-warning-300" role="alert">
+        {error}
+      </p>
     </div>
   );
 };

--- a/src/shared/ui/FormErrorMessage.tsx
+++ b/src/shared/ui/FormErrorMessage.tsx
@@ -11,15 +11,17 @@ const FormErrorMessage: React.FC<FormErrorMessageProps> = ({ error, className = 
   return (
     <div
       aria-live="polite"
-      className={[
-        'flex items-center gap-2 rounded-300 bg-warning-0 px-4 py-3',
-        className,
-      ].join(' ')}
+      className={['rounded-300 bg-warning-0 flex items-center gap-2 px-4 py-3', className].join(
+        ' ',
+      )}
     >
-      <span className="material-symbols-outlined flex-shrink-0 !text-[18px] text-warning-200">
+      <span className="material-symbols-outlined text-warning-200 flex-shrink-0 !text-[18px]">
         error
       </span>
-      <p className="text-detail-regular text-warning-300" role="alert">
+      <p
+        className="text-detail-regular text-warning-300"
+        role="alert"
+      >
         {error}
       </p>
     </div>

--- a/src/shared/ui/SectionHeader.tsx
+++ b/src/shared/ui/SectionHeader.tsx
@@ -3,13 +3,31 @@ import React from 'react';
 interface SectionHeaderProps {
   title: string;
   description: string;
+  size?: 'sm' | 'md';
 }
 
-const SectionHeader: React.FC<SectionHeaderProps> = ({ title, description }) => (
-  <header className="mb-10 text-center sm:mb-14">
-    <h2 className="text-heading-2-bold sm:text-heading-1-bold text-primary-400 mb-3">{title}</h2>
-    <p className="text-detail-regular sm:text-body-3-regular text-neutral-500">{description}</p>
-  </header>
-);
+const SectionHeader: React.FC<SectionHeaderProps> = ({ title, description, size = 'md' }) => {
+  const styles = {
+    md: {
+      wrapper: 'mb-10 sm:mb-14',
+      title: 'text-heading-2-bold sm:text-heading-1-bold',
+      desc: 'text-detail-regular sm:text-body-3-regular',
+    },
+    sm: {
+      wrapper: 'mb-6',
+      title: 'text-heading-3-bold',
+      desc: 'text-detail-regular',
+    },
+  };
+
+  const s = styles[size];
+
+  return (
+    <header className={`text-center ${s.wrapper}`}>
+      <h2 className={`${s.title} text-primary-400 mb-1.5`}>{title}</h2>
+      <p className={`${s.desc} text-neutral-500`}>{description}</p>
+    </header>
+  );
+};
 
 export default SectionHeader;

--- a/src/shared/ui/common/Input.tsx
+++ b/src/shared/ui/common/Input.tsx
@@ -12,7 +12,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className = '', fullWidth = false, error = false, textAlign = 'left', ...props }, ref) => {
     // 공통 스타일
     const baseStyles = [
-      'h-12 px-3',
+      'h-9 px-3',
       'rounded-200',
       'text-body-3-regular',
       'bg-neutral-0',

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,6 +9,22 @@
 
 /* 커스텀 유틸리티 레이어 시작 */
 @layer utilities {
+  /* 🎈 fadeIn 애니메이션 (페이지 전환용) */
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .animate-fade-in {
+    animation: fadeIn 0.35s ease-out both;
+  }
+
   /* 🌊 wave-fill 애니메이션 정의*/
   @keyframes wave-fill {
     0% {


### PR DESCRIPTION
### ✅ PR 설명

auth 관련 페이지들의 전반적인 디자인을 수정했습니다

### 🏗 작업 내용

- [x] 로그인 페이지 디자인 변경
- [x] 약관 페이지 디자인 변경
- [x] 약관 모달 디자인 변경
- [x] 회원가입 페이지 디자인 변경
- [x] auth 관련 카드들 래퍼로 분리

### 📸 테스트 결과 (선택)

> <img width="1242" height="1221" alt="image" src="https://github.com/user-attachments/assets/2de7b281-797b-485a-a4c8-3ea8d4b1785d" />

### 🔗 관련 이슈 (선택)


### 🚨 참고 사항 (선택)

