### PR TITLE
[Fix] 최종 제출용 전반적인 UX 및 폼 에러 처리 개선 (#91)

### DIFF
--- a/src/features/complaint/components/CaseDetailModal.tsx
+++ b/src/features/complaint/components/CaseDetailModal.tsx
@@ -11,70 +11,67 @@ const CaseDetailModal: React.FC<Props> = ({ ragCase, onClose }) => {
   return (
     <div
       className={[
-        'relative flex flex-col',
-        'w-full max-w-2xl', // 🔹 CharacterModal보다 살짝 넓게
-        'rounded-400 bg-neutral-0',
-        'px-6 py-8 sm:px-10 sm:py-10',
-        'shadow-[0_16px_40px_rgba(15,23,42,0.25)]',
+        'relative flex w-full max-w-2xl flex-col overflow-hidden',
+        'rounded-2xl bg-white',
+        'shadow-[0_16px_40px_rgba(15,23,42,0.2)]',
       ].join(' ')}
     >
-      {/* 닫기 버튼 (우상단 X) */}
-      <button
-        type="button"
-        onClick={onClose}
-        className="hover:text-warning-300 absolute top-4 right-4 text-neutral-400"
-      >
-        <span className="material-symbols-outlined text-[20px]">close</span>
-      </button>
-
-      {/* 헤더 영역 */}
-      <header className="mb-4 flex flex-col gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-200 bg-primary-0 text-body-2-regular text-primary-600 px-3 py-1">
-            사건 번호
-          </span>
-          <span className="text-body-2-bold text-neutral-900">{ragCase.case_no}</span>
+      {/* 헤더 */}
+      <div className="flex items-start justify-between border-b border-neutral-100 px-6 py-5">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <span
+              className="material-symbols-outlined text-primary-400"
+              style={{ fontSize: '22px' }}
+            >
+              gavel
+            </span>
+            <span className="text-body-1-bold text-neutral-900">{ragCase.case_no}</span>
+          </div>
+          {ragCase.label && <p className="text-body-3-regular text-neutral-500">{ragCase.label}</p>}
         </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
+        >
+          <span
+            className="material-symbols-outlined"
+            style={{ fontSize: '20px' }}
+          >
+            close
+          </span>
+        </button>
+      </div>
 
-        {ragCase.label && (
-          <p className="text-body-3-regular pb-6 text-neutral-700">{ragCase.label}</p>
-        )}
-
+      {/* 본문 - 스크롤 가능 */}
+      <div className="balaw-scrollbar max-h-[60vh] overflow-y-auto">
+        {/* 유사도 */}
         {ragCase.similarity && (
-          <div className="flex flex-wrap items-center gap-2 pb-6">
-            <span className="rounded-200 bg-primary-0 text-body-2-regular text-primary-600 px-3 py-1">
-              내 사건과의 유사도
-            </span>
-            <span className="text-body-4-regular whitespace-pre-line text-neutral-700">
+          <div className="border-b border-neutral-100 px-6 py-4">
+            <p className="text-detail-regular mb-2 text-neutral-400">유사 포인트</p>
+            <p className="text-body-3-regular leading-relaxed text-neutral-700">
               {ragCase.similarity}
-            </span>
+            </p>
           </div>
         )}
 
         {/* 사건 개요 */}
-        <div className="pb-6">
-          <div className="mb-2 flex items-center gap-2">
-            <span className="rounded-200 bg-primary-0 text-body-2-regular text-primary-600 px-3 py-1">
-              사건 개요
-            </span>
-          </div>
-          <p className="text-body-4-regular whitespace-pre-line text-neutral-700">
-            {ragCase.summary || '요약 정보가 없습니다.'}
+        <div className="border-b border-neutral-100 px-6 py-4">
+          <p className="text-detail-regular mb-2 text-neutral-400">사건 개요</p>
+          <p className="text-body-3-regular leading-relaxed whitespace-pre-line text-neutral-700">
+            {ragCase.summary || '요약 정보가 없어요.'}
           </p>
         </div>
 
         {/* 판결 결과 */}
-        <div>
-          <div className="mb-2 flex items-center gap-2">
-            <span className="rounded-200 bg-primary-0 text-body-2-regular text-primary-600 px-3 py-1">
-              판결 결과
-            </span>
-          </div>
-          <p className="text-body-4-regular whitespace-pre-line text-neutral-700">
-            {ragCase.result || '판결 결과 정보가 없습니다.'}
+        <div className="px-6 py-4">
+          <p className="text-detail-regular mb-2 text-neutral-400">판결 결과</p>
+          <p className="text-body-3-regular leading-relaxed whitespace-pre-line text-neutral-700">
+            {ragCase.result || '판결 결과 정보가 없어요.'}
           </p>
         </div>
-      </header>
+      </div>
     </div>
   );
 };

--- a/src/features/complaint/components/ChatBubble.tsx
+++ b/src/features/complaint/components/ChatBubble.tsx
@@ -1,3 +1,5 @@
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
+
 import {
   bubbleWidthClasses,
   buildSurface,
@@ -7,57 +9,54 @@ import {
 import type { Side } from '@/features/complaint/components/chat/types/side';
 import { useMultilineDetect } from '@/features/complaint/components/chat/utils/multilineDetect';
 
-// 말풍선 컴포넌트 Props
 type BubbleProps = {
-  side: Side; // 말풍선이 왼쪽(bot)인지 오른쪽(me)인지
-  text: string; // 채팅 메시지 텍스트
-  time: string; // 타임스탬프
-  srLabel: string; // 스크린리더 접근성 레이블
+  side: Side;
+  text: string;
+  time: string;
+  srLabel: string;
   isTyping?: boolean;
 };
 
 export function ChatBubble({ side, text, time, srLabel, isTyping }: BubbleProps) {
-  // 말풍선의 최대 폭 클래스
-  const widthClasses = bubbleWidthClasses;
-
   const { ref: pRef, isMultiline } = useMultilineDetect(text);
 
-  // 왼쪽 or 오른쪽 정렬 여부
   const isLeft = side === 'left';
-  // 왼쪽 말풍선은 항상 text-left | 오른쪽 말풍선인데 여러 줄이면 text-left, 아니면 text-right
   const alignClass = isLeft ? 'text-left' : isMultiline ? 'text-left' : 'text-right';
 
   return (
     <div
-      className={`flex w-full ${isLeft ? 'justify-start' : 'justify-end'} py-3`}
+      className={`flex w-full ${isLeft ? 'justify-start' : 'justify-end'} py-1.5`}
       role="listitem"
       aria-label={srLabel}
     >
-      {/* 말풍선 최대 폭 제한 컨테이너 */}
-      <div className={`${widthClasses}`}>
-        {/* 말풍선 본체 */}
-        <div className={buildSurface(side)}>
-          {/* 스크린리더 전용 텍스트 */}
-          <span className="sr-only">{srLabel}</span>
+      {/* 봇 아바타 */}
+      {isLeft && (
+        <img
+          src={characterUrl}
+          alt="바로"
+          className="mr-2 h-8 w-8 shrink-0 self-start rounded-full"
+          draggable={false}
+        />
+      )}
 
-          {/* 실제 메시지 텍스트 */}
+      <div className={bubbleWidthClasses}>
+        <div className={buildSurface(side)}>
+          <span className="sr-only">{srLabel}</span>
           <p
             ref={isTyping ? undefined : pRef}
             className={`${textBase()} ${alignClass}`}
           >
             {isTyping ? (
-              <span className="inline-flex items-center gap-1 px-4">
-                <span className="bg-primary-200 h-[5px] w-[5px] animate-bounce rounded-full" />
-                <span className="bg-primary-300 h-[5px] w-[5px] animate-bounce rounded-full [animation-delay:0.15s]" />
-                <span className="bg-primary-400 h-[5px] w-[5px] animate-bounce rounded-full [animation-delay:0.3s]" />
+              <span className="inline-flex items-center gap-1 px-2">
+                <span className="h-[6px] w-[6px] animate-bounce rounded-full bg-neutral-400" />
+                <span className="h-[6px] w-[6px] animate-bounce rounded-full bg-neutral-400 [animation-delay:0.15s]" />
+                <span className="h-[6px] w-[6px] animate-bounce rounded-full bg-neutral-400 [animation-delay:0.3s]" />
               </span>
             ) : (
               text
             )}
           </p>
         </div>
-
-        {/* 타임스탬프 */}
         <div className={buildTime(side)}>{time}</div>
       </div>
     </div>

--- a/src/features/complaint/components/Question.tsx
+++ b/src/features/complaint/components/Question.tsx
@@ -1,6 +1,4 @@
-import React, { useEffect, useState } from 'react';
-
-import Tooltip from '@/shared/ui/Tooltip';
+import React from 'react';
 
 import type { BinaryAnswer, PrecheckQuestion } from '@/features/complaint/types/complaint';
 
@@ -11,72 +9,61 @@ export interface QuestionProps {
   onToggleConfirm: (id: PrecheckQuestion['id']) => void;
   onSetBinary: (id: PrecheckQuestion['id'], answer: BinaryAnswer) => void;
   forceOpenInfo?: boolean;
+  isLast?: boolean;
 }
 
-const Question: React.FC<QuestionProps> = ({ q, onToggleConfirm, onSetBinary, forceOpenInfo }) => {
-  const [showInfo, setShowInfo] = useState(false);
-
-  const toggleInfo = () => setShowInfo((prev) => !prev);
-  const closeInfo = () => setShowInfo(false);
-
-  useEffect(() => {
-    if (forceOpenInfo && q.description) {
-      setShowInfo(true);
-    }
-  }, [forceOpenInfo, q.description]);
-
-  const iconColor = showInfo
-    ? forceOpenInfo
-      ? 'text-warning-200 hover:text-warning-300'
-      : 'text-primary-400'
-    : 'text-neutral-400 hover:text-primary-400';
-
+const Question: React.FC<QuestionProps> = ({
+  q,
+  onToggleConfirm,
+  onSetBinary,
+  forceOpenInfo,
+  isLast,
+}) => {
   return (
-    <div className="flex w-[420px] flex-col gap-1 px-3">
-      <div className="flex w-[400px] items-center justify-between gap-2">
-        <p className="text-body-2-regular leading-tight font-medium text-black">{q.title}</p>
-        <div className="relative flex items-center justify-center">
-          <button
-            type="button"
-            className={['transition-colors focus:outline-none', iconColor].join(' ')}
-            onClick={toggleInfo}
-          >
-            <span
-              className="material-symbols-outlined leading-none"
-              style={{ fontSize: '20px' }}
-            >
-              info
-            </span>
-          </button>
+    <div
+      className={[
+        'flex flex-col gap-3 px-5 py-4',
+        !isLast ? 'border-b border-neutral-100' : '',
+      ].join(' ')}
+    >
+      {/* 질문 제목 */}
+      <p className="text-body-3-bold md:text-body-2-bold text-neutral-800">{q.title}</p>
 
-          {q.description && (
-            <Tooltip
-              open={showInfo}
-              onClose={closeInfo}
-              text={q.description}
-              position="right"
-              forced={forceOpenInfo}
-            />
-          )}
-        </div>
-      </div>
+      {/* 설명 - 항상 표시 */}
+      {q.description && (
+        <p
+          className={[
+            'text-detail-regular md:text-body-3-regular',
+            forceOpenInfo ? 'text-warning-200' : 'text-neutral-400',
+          ].join(' ')}
+        >
+          {q.description
+            .split(/(?<=\.)\s*/)
+            .filter(Boolean)
+            .map((sentence, i, arr) => (
+              <React.Fragment key={i}>
+                {sentence}
+                {i < arr.length - 1 && <br />}
+              </React.Fragment>
+            ))}
+        </p>
+      )}
 
-      <div className="flex h-12 w-[400px] items-center justify-end gap-3">
+      {/* 응답 영역 */}
+      <div className="flex items-center justify-end gap-2">
         {q.kind === 'binary' ? (
           <>
-            {/* 예 = 붉은색 */}
-            <Chip
-              active={q.answer === 'yes'}
-              onClick={() => onSetBinary(q.id, 'yes')}
-              label="예"
-              colorScheme="warning"
-            />
-            {/* 아니오 = 파란색 */}
             <Chip
               active={q.answer === 'no'}
               onClick={() => onSetBinary(q.id, 'no')}
               label="아니오"
               colorScheme="primary"
+            />
+            <Chip
+              active={q.answer === 'yes'}
+              onClick={() => onSetBinary(q.id, 'yes')}
+              label="예"
+              colorScheme="warning"
             />
           </>
         ) : (

--- a/src/features/complaint/components/WizardNavButtons.tsx
+++ b/src/features/complaint/components/WizardNavButtons.tsx
@@ -20,26 +20,43 @@ const WizardNavButtons: React.FC<WizardNavButtonsProps> = ({
   nextLabel = '다음',
 }) => {
   return (
-    <div className="mx-auto flex w-full max-w-[420px] items-center justify-center">
-      <div className="flex w-full items-center justify-between gap-3">
-        <Button
-          variant="primary"
-          size="md"
-          fullWidth
-          onClick={onPrev}
-          disabled={disablePrev}
-        >
-          {prevLabel}
-        </Button>
-        <Button
-          variant="primary"
-          size="md"
-          fullWidth
-          onClick={onNext}
-          disabled={isNextDisabled}
-        >
-          {nextLabel}
-        </Button>
+    <div className="w-full shrink-0">
+      {/* 바 본체 */}
+      <div className="px-6 pt-2 pb-3">
+        <div className="mx-auto flex w-full max-w-[420px] items-center justify-between">
+          {/* 이전: 텍스트 버튼 */}
+          <button
+            type="button"
+            onClick={onPrev}
+            disabled={disablePrev}
+            className="text-body-3-regular flex items-center gap-1 text-neutral-500 transition-colors hover:text-neutral-700 disabled:invisible"
+          >
+            <span
+              className="material-symbols-outlined"
+              style={{ fontSize: '18px' }}
+            >
+              arrow_back
+            </span>
+            {prevLabel}
+          </button>
+
+          {/* 다음: primary 버튼 */}
+          <Button
+            variant="primary"
+            size="md"
+            onClick={onNext}
+            disabled={isNextDisabled}
+            className="min-w-[120px]"
+          >
+            {nextLabel}
+            <span
+              className="material-symbols-outlined ml-1"
+              style={{ fontSize: '18px' }}
+            >
+              arrow_forward
+            </span>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/complaint/components/WizardProgress.tsx
+++ b/src/features/complaint/components/WizardProgress.tsx
@@ -3,60 +3,82 @@ import React from 'react';
 import { useComplaintWizard } from '@/features/complaint/stores/useComplaintWizard';
 
 type Props = {
-  // 나가기 콜백 함수
   onExit?: () => void;
-
-  // 외부에서 전달할 추가 tailwind 클래스
   className?: string;
 };
 
+const STEP_LABELS: Record<number, { icon: string; label: string }> = {
+  0: { icon: 'play_circle', label: '시작하기' },
+  1: { icon: 'info', label: '안내 확인' },
+  2: { icon: 'person', label: '고소인 정보' },
+  3: { icon: 'group', label: '피고소인 정보' },
+  4: { icon: 'folder_open', label: '증거 제출' },
+  5: { icon: 'chat', label: '채팅 안내' },
+  6: { icon: 'smart_toy', label: 'AI 상담' },
+  7: { icon: 'description', label: '고소장 생성' },
+  8: { icon: 'download', label: '고소장 다운로드' },
+};
+
 const WizardProgress: React.FC<Props> = ({ onExit, className = '' }) => {
-  // 진행률 (0 ~ 100) -> 스토어의 현재 step / total에 따라 계산됨
   const percent = useComplaintWizard((s) => s.percentage());
+  const step = useComplaintWizard((s) => s.state.step);
+
+  const current = STEP_LABELS[step] ?? { icon: 'circle', label: `${step + 1}단계` };
 
   return (
-    // 상단 진행 영역 전체 래퍼
-    <section className={`flex w-full flex-col gap-4 ${className}`}>
-      {/* 진행바 컨테이너: 배지 포지셔닝을 위해 relative */}
-      <div className="relative w-full">
-        {/* 회색 진행바 */}
+    <section className={`flex w-full flex-col gap-3 ${className}`}>
+      {/* 상단: 단계 정보 + 나가기 버튼 */}
+      <div className="flex items-center justify-between">
+        {/* 왼쪽: 아이콘 + 단계 라벨 */}
+        <div className="flex items-center gap-2">
+          <span
+            className="material-symbols-outlined text-primary-400"
+            style={{ fontSize: '20px' }}
+          >
+            {current.icon}
+          </span>
+          <span className="text-body-3-bold text-neutral-800">{current.label}</span>
+        </div>
+
+        {/* 오른쪽: 단계 수 + 나가기 */}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onExit}
+            className="text-detail-bold flex items-center gap-1 text-neutral-400 transition-colors hover:text-neutral-600"
+          >
+            <span
+              className="material-symbols-outlined"
+              style={{ fontSize: '16px' }}
+            >
+              close
+            </span>
+            종료
+          </button>
+        </div>
+      </div>
+
+      {/* 진행바 */}
+      <div className="relative pb-5">
         <div
-          className="rounded-400 h-3 w-full overflow-hidden bg-neutral-200/50"
+          className="h-2 w-full overflow-hidden rounded-full bg-neutral-100"
           role="progressbar"
           aria-valuenow={percent}
           aria-valuemin={0}
           aria-valuemax={100}
         >
-          {/* 실제 채워지는(파란색) 진행 바: width %로 제어 */}
           <div
-            className="bg-primary-400 rounded-400 h-full transition-[width] duration-300 ease-out"
+            className="from-primary-300 to-primary-400 h-full rounded-full bg-gradient-to-r shadow-[0_0_8px_rgba(59,130,246,0.4),0_0_2px_rgba(59,130,246,0.6)] transition-[width] duration-500 ease-out"
             style={{ width: `${percent}%` }}
           />
         </div>
-      </div>
-
-      {/* 나가기 버튼 -> 우측 정렬 */}
-      <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={onExit}
-          className={[
-            'inline-flex items-center justify-center gap-2',
-            'rounded-300 bg-neutral-0 h-9 border border-neutral-300 px-4 py-1.5',
-            'text-detail-bold text-neutral-600 shadow-sm transition-all',
-            'hover:bg-neutral-100/50 hover:text-neutral-800',
-            'focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400',
-          ].join(' ')}
+        {/* 퍼센트 라벨 - 바 아래, 끝에 따라다님 */}
+        <span
+          className="text-detail-bold text-primary-400 absolute top-3 -translate-x-1/2 transition-[left] duration-500 ease-out"
+          style={{ left: `${percent}%` }}
         >
-          <span
-            className="material-symbols-outlined leading-none text-neutral-600"
-            style={{ fontSize: '16px' }}
-            aria-hidden
-          >
-            logout
-          </span>
-          작성 종료
-        </button>
+          {percent}%
+        </span>
       </div>
     </section>
   );

--- a/src/features/complaint/components/chat/styles/chat.ts
+++ b/src/features/complaint/components/chat/styles/chat.ts
@@ -5,35 +5,23 @@ import type { Side } from '@/features/complaint/components/chat/types/side';
 export function buildSurface(side: Side) {
   const isLeft = side === 'left';
   const palette = isLeft ? bubblePalette.bot : bubblePalette.me;
-  const corner = isLeft ? 'rounded-bl' : 'rounded-br';
-  return [
-    palette.bg,
-    palette.border,
-    palette.text,
-    'border',
-    'rounded-400',
-    corner,
-    'px-4',
-    'py-2',
-  ].join(' ');
+  const corner = isLeft ? 'rounded-tl-none' : 'rounded-tr-none';
+  return [palette.bg, palette.text, 'rounded-2xl', corner, 'px-4', 'py-3'].join(' ');
 }
 
 /** 채팅 텍스트 스타일 */
 export function textBase() {
-  return ['text-body-2-regular', 'break-words', 'whitespace-pre-wrap'].join(' ');
+  return ['text-body-3-regular', 'break-words', 'whitespace-pre-wrap', 'leading-relaxed'].join(' ');
 }
 
-/** 타임 스탬프 스타일
- * bot이 보낸거면 왼쪽에 패딩을 주고,
- * me가 보낸거면 오른쪽에 패딩을 준 후 오른쪽 정렬 함
- */
+/** 타임스탬프 스타일 */
 export function buildTime(side: Side) {
   return [
     'mt-1',
     'text-detail-regular',
     'text-neutral-400',
     'tabular-nums',
-    side === 'left' ? 'pl-2' : 'pr-2 text-right',
+    side === 'left' ? 'pl-1' : 'pr-1 text-right',
   ].join(' ');
 }
 

--- a/src/features/complaint/components/chat/tokens/chatTokens.ts
+++ b/src/features/complaint/components/chat/tokens/chatTokens.ts
@@ -1,20 +1,10 @@
-/**
- * 말풍선 생상 팔레트
- * bot은 ai 메시지용
- * me는 사용자가 보낸 메시지용
- *
- * as const를 통해 각 값을 리터럴 타입으로 고정했음
- */
+/** 말풍선 색상 팔레트 */
 export const bubblePalette = {
-  bot: { bg: 'bg-primary-0/50', border: 'border-primary-400', text: 'text-neutral-1000' },
-  me: { bg: 'bg-neutral-0', border: 'border-primary-400', text: 'text-neutral-1000' },
+  bot: { bg: 'bg-neutral-100', text: 'text-neutral-900' },
+  me: { bg: 'bg-primary-400', text: 'text-white' },
 } as const;
 
-/**
- * 말풍선 최대 너비 토큰
- * base, sm, md, lg 브레이크포인트마다 다른 max-width 클래스를 제공해줌
- * (예를 들어 sm 이상이면 최대 너비가 75%임)
- */
+/** 말풍선 최대 너비 (반응형) */
 export const bubbleMaxW = {
   base: 'max-w-[82%]',
   sm: 'sm:max-w-[75%]',

--- a/src/features/complaint/pages/ComplaintWizardPage.tsx
+++ b/src/features/complaint/pages/ComplaintWizardPage.tsx
@@ -18,26 +18,16 @@ import {
   registerEvidence,
   registerRelatedCases,
 } from '@/features/complaint/apis/complaints';
-import CaseDetailModal from '@/features/complaint/components/CaseDetailModal';
 import WizardNavButtons from '@/features/complaint/components/WizardNavButtons';
 import WizardProgress from '@/features/complaint/components/WizardProgress';
-import AccusedExtraInfoSection, {
-  type AccusedExtraInfo,
-  type AccusedExtraInfoSectionHandle,
-} from '@/features/complaint/sections/AccusedExtraInfoSection';
 import AccusedInfoSection, {
-  type AccusedBasicInfo,
   type AccusedInfoSectionHandle,
 } from '@/features/complaint/sections/AccusedInfoSection';
 import ChatInfoSection from '@/features/complaint/sections/ChatInfoSection';
 import ChatWindowSection from '@/features/complaint/sections/ChatWindowSection';
 import ComplaintDownloadSection from '@/features/complaint/sections/ComplaintDownloadSection';
 import ComplaintEntrySection from '@/features/complaint/sections/ComplaintEntrySection';
-import type { ComplainantExtraInfoSectionHandle } from '@/features/complaint/sections/ComplaintExtraInfoSection';
-import type { ComplainantExtraInfo } from '@/features/complaint/sections/ComplaintExtraInfoSection';
-import ComplainantExtraInfoSection from '@/features/complaint/sections/ComplaintExtraInfoSection';
 import type { ComplainantInfoSectionHandle } from '@/features/complaint/sections/ComplaintInfoSection';
-import type { ComplaintBasicInfo } from '@/features/complaint/sections/ComplaintInfoSection';
 import ComplainantInfoSection from '@/features/complaint/sections/ComplaintInfoSection';
 import ComplaintIntroSection from '@/features/complaint/sections/ComplaintIntroSection';
 import ComplaintPreviewSection from '@/features/complaint/sections/ComplaintPreviewSection';
@@ -67,16 +57,39 @@ const ComplaintWizardPage: React.FC = () => {
   const nextRaw = useComplaintWizard((s) => s.next);
   const prev = useComplaintWizard((s) => s.prev);
   const resetWizard = useComplaintWizard((s) => s.reset);
+  const allChecked = useComplaintWizard((s) => s.allChecked());
   const setStep = useComplaintWizard((s) => s.setStep);
 
-  const [isChatCompleted, setIsChatCompleted] = useState(false);
+  const [, setIsChatCompleted] = useState(false);
 
-  const [entryMode, setEntryMode] = useState<'new' | 'resume' | null>(null);
+  // 채팅 단계에서만 html 스크롤 차단
+  useEffect(() => {
+    if (step === 6) {
+      document.documentElement.style.overflow = 'hidden';
+      document.documentElement.style.height = '100%';
+    } else {
+      document.documentElement.style.overflow = '';
+      document.documentElement.style.height = '';
+    }
+    return () => {
+      document.documentElement.style.overflow = '';
+      document.documentElement.style.height = '';
+    };
+  }, [step]);
+
+  const newMode = fromState?.mode === 'new';
+  const [entryMode, setEntryMode] = useState<'new' | 'resume' | null>(newMode ? 'new' : null);
+
+  // 외부에서 mode: 'new'로 진입하면 step 0 건너뛰기
+  useEffect(() => {
+    if (newMode && step === 0) {
+      setStep(1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const complainantRef = useRef<ComplainantInfoSectionHandle>(null);
-  const complainantExtraRef = useRef<ComplainantExtraInfoSectionHandle>(null);
   const accusedRef = useRef<AccusedInfoSectionHandle>(null);
-  const accusedExtraRef = useRef<AccusedExtraInfoSectionHandle>(null);
   const evidenceRef = useRef<EvidenceInfoSectionHandle>(null);
 
   // AI 메타 정보 (이 페이지에서만 관리)
@@ -85,8 +98,6 @@ const ComplaintWizardPage: React.FC = () => {
   const [ragSearchStarted, setRagSearchStarted] = useState(false);
 
   const [complaintId, setComplaintId] = useState<number | null>(initialComplaintIdFromState);
-  const [complainantBasicInfo, setComplainantBasicInfo] = useState<ComplaintBasicInfo | null>(null);
-  const [accusedBasicInfo, setAccusedBasicInfo] = useState<AccusedBasicInfo | null>(null);
 
   const [generatedComplaint, setGeneratedComplaint] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -106,7 +117,7 @@ const ComplaintWizardPage: React.FC = () => {
   useEffect(() => {
     if (resumeMode && initialComplaintIdFromState) {
       setComplaintId(initialComplaintIdFromState);
-      setStep(8); // 0: 엔트리, 1: 인트로, ..., 7: 증거, 8: 채팅
+      setStep(6); // 0: 엔트리, 1: 인트로, 2: 고소인, 3: 피고소인, 4: 채팅안내, 5: 증거, 6: 채팅
     }
   }, [resumeMode, initialComplaintIdFromState, setStep]);
 
@@ -133,36 +144,22 @@ const ComplaintWizardPage: React.FC = () => {
       return;
     }
 
-    // 2: 고소인 기본정보 → 로컬 상태만 저장
+    // 2: 고소인 정보 (기본+추가 통합) → complaint 생성 + 관련 사건 등록
     if (step === 2) {
       if (!complainantRef.current) return;
 
       try {
-        const basic = await complainantRef.current.save();
-        setComplainantBasicInfo(basic);
-        nextRaw();
-      } catch {
-        // 섹션 내부에서 에러 처리
-      }
-      return;
-    }
-
-    // 3: 고소인 추가정보 → complaint 생성 + 관련 사건 등록
-    if (step === 3) {
-      if (!complainantBasicInfo || !complainantExtraRef.current) return;
-
-      try {
-        const extra: ComplainantExtraInfo = await complainantExtraRef.current.save();
+        const info = await complainantRef.current.save();
 
         const payload: ComplainantInfoCreate = {
-          complainant_name: complainantBasicInfo.name,
-          complainant_email: complainantBasicInfo.unknownEmail ? '' : complainantBasicInfo.email,
-          complainant_address: complainantBasicInfo.unknownAddr ? '' : complainantBasicInfo.address,
-          complainant_phone: complainantBasicInfo.unknownPhone ? '' : complainantBasicInfo.phone,
-          complainant_job: extra.unknownOccupation ? '' : extra.occupation,
-          complainant_office_address: extra.unknownOfficeAddress ? '' : extra.officeAddress,
-          complainant_office_phone: extra.unknownOfficePhone ? '' : extra.officePhone,
-          complainant_home_phone: extra.unknownHomePhone ? '' : extra.homePhone,
+          complainant_name: info.name,
+          complainant_email: info.unknownEmail ? '' : info.email,
+          complainant_address: info.unknownAddr ? '' : info.address,
+          complainant_phone: info.unknownPhone ? '' : info.phone,
+          complainant_job: info.unknownOccupation ? '' : info.occupation,
+          complainant_office_address: info.unknownOfficeAddress ? '' : info.officeAddress,
+          complainant_office_phone: info.unknownOfficePhone ? '' : info.officePhone,
+          complainant_home_phone: info.unknownHomePhone ? '' : info.homePhone,
         };
 
         const res = await createComplaint(payload);
@@ -193,36 +190,21 @@ const ComplaintWizardPage: React.FC = () => {
       return;
     }
 
-    // 4: 피고소인 기본정보
-    if (step === 4) {
-      try {
-        const basic = await accusedRef.current?.save();
-        if (basic) {
-          setAccusedBasicInfo(basic);
-          nextRaw();
-        }
-      } catch {
-        // 섹션 내부에서 에러 처리
-      }
-      return;
-    }
-
-    // 5: 피고소인 추가정보 → registerAccused
-    if (step === 5) {
-      if (!complaintId || !accusedBasicInfo) return;
-      if (!accusedExtraRef.current) return;
+    // 3: 피고소인 정보 (기본 + 추가 통합) → registerAccused
+    if (step === 3) {
+      if (!complaintId) return;
+      if (!accusedRef.current) return;
 
       try {
-        const extra: AccusedExtraInfo = await accusedExtraRef.current.save();
-
+        const info = await accusedRef.current.save();
         const payload: AccusedInfoCreate = {
-          accused_name: accusedBasicInfo.name,
-          accused_email: accusedBasicInfo.email,
-          accused_address: accusedBasicInfo.address,
-          accused_phone: accusedBasicInfo.phone,
-          accused_job: extra.occupation,
-          accused_office_address: extra.officeAddress,
-          accused_etc: extra.etc,
+          accused_name: info.name,
+          accused_email: info.email,
+          accused_address: info.address,
+          accused_phone: info.phone,
+          accused_job: info.occupation,
+          accused_office_address: info.officeAddress,
+          accused_etc: info.etc,
         };
 
         await registerAccused(complaintId, payload);
@@ -233,8 +215,8 @@ const ComplaintWizardPage: React.FC = () => {
       return;
     }
 
-    // 7: 증거 섹션 → registerEvidence 후 채팅 단계(8)로
-    if (step === 7) {
+    // 4: 증거 섹션 → registerEvidence
+    if (step === 4) {
       if (!complaintId) return;
       if (!evidenceRef.current) return;
 
@@ -246,7 +228,7 @@ const ComplaintWizardPage: React.FC = () => {
         };
 
         await registerEvidence(complaintId, payload);
-        nextRaw(); // → step 8 (ChatWindowSection)
+        nextRaw(); // → step 5 (채팅 안내)
       } catch (e) {
         console.error('failed to register evidence', e);
       }
@@ -254,8 +236,8 @@ const ComplaintWizardPage: React.FC = () => {
       return;
     }
 
-    // 8: 채팅 완료 후 → 최종 고소장 생성 + 미리보기(9)
-    if (step === 8) {
+    // 6: 채팅 완료 후 → 최종 고소장 생성 + 미리보기(7)
+    if (step === 6) {
       if (!complaintId) return;
 
       // 버튼 누르는 즉시 모달 띄우기
@@ -283,7 +265,7 @@ const ComplaintWizardPage: React.FC = () => {
       return;
     }
 
-    if (step === 10) {
+    if (step === 8) {
       resetWizard(); // 위자드 상태 초기화
       navigate('/'); // 홈으로 이동
       return;
@@ -296,12 +278,19 @@ const ComplaintWizardPage: React.FC = () => {
   const chatMode: 'new' | 'resume' = resumeMode ? 'resume' : 'new';
 
   return (
-    <div className="bg-neutral-0 flex min-h-screen w-full flex-col">
+    <div
+      className={`bg-neutral-0 flex w-full flex-col ${step === 6 ? 'h-screen overflow-hidden' : 'min-h-screen'}`}
+    >
       <Header />
-      <main className="mx-auto flex w-full max-w-[1200px] flex-1 flex-col px-6 py-4">
-        <WizardProgress onExit={handleExit} />
-        {/* 위자드 본문: 0~7단계 (420px 카드) */}
-        <div className="mx-auto w-full max-w-[420px]">
+      <main
+        className={`mx-auto flex w-full max-w-[1200px] flex-1 flex-col px-6 py-4 ${step === 6 ? 'min-h-0 overflow-hidden' : ''}`}
+      >
+        <WizardProgress
+          onExit={handleExit}
+          className="mb-4 shrink-0"
+        />
+        {/* 위자드 본문: 0~7단계 */}
+        <div className={step >= 6 ? 'hidden' : 'flex min-h-0 flex-1 flex-col'}>
           {/* 0: 시작 선택 (새로 작성 / 이어쓰기 / 목록 보기) */}
           {step === 0 && (
             <ComplaintEntrySection
@@ -312,23 +301,18 @@ const ComplaintWizardPage: React.FC = () => {
           )}
 
           {/* 1: 인트로 / 안내 */}
-          <div className={step === 1 ? 'block' : 'hidden'}>
+          <div className={step === 1 ? 'flex flex-1 flex-col' : 'hidden'}>
             <ComplaintIntroSection />
           </div>
 
-          {/* 2: 고소인 기본정보 */}
-          <div className={step === 2 ? 'block' : 'hidden'}>
+          {/* 2: 고소인 정보 */}
+          <div className={step === 2 ? 'flex flex-1 flex-col' : 'hidden'}>
             <ComplainantInfoSection ref={complainantRef} />
           </div>
 
-          {/* 3: 고소인 추가정보 */}
-          <div className={step === 3 ? 'block' : 'hidden'}>
-            <ComplainantExtraInfoSection ref={complainantExtraRef} />
-          </div>
-
-          {/* 4: 피고소인 기본정보 */}
+          {/* 3: 피고소인 정보 */}
           {typeof complaintId === 'number' && Number.isFinite(complaintId) && complaintId > 0 && (
-            <div className={step === 4 ? 'block' : 'hidden'}>
+            <div className={step === 3 ? 'flex flex-1 flex-col' : 'hidden'}>
               <AccusedInfoSection
                 ref={accusedRef}
                 complaintId={complaintId}
@@ -336,40 +320,35 @@ const ComplaintWizardPage: React.FC = () => {
             </div>
           )}
 
-          {/* 5: 피고소인 추가정보 */}
+          {/* 4: 증거 제출 */}
           {typeof complaintId === 'number' && Number.isFinite(complaintId) && complaintId > 0 && (
-            <div className={step === 5 ? 'block' : 'hidden'}>
-              <AccusedExtraInfoSection
-                ref={accusedExtraRef}
-                complaintId={complaintId}
-              />
+            <div className={step === 4 ? 'flex flex-1 flex-col' : 'hidden'}>
+              <EvidenceInfoSection ref={evidenceRef} />
             </div>
           )}
 
-          {/* 6: 채팅 안내 */}
-          <div className={step === 6 ? 'block' : 'hidden'}>
+          {/* 5: 채팅 안내 */}
+          <div className={step === 5 ? 'flex flex-1 flex-col' : 'hidden'}>
             <ChatInfoSection />
           </div>
-
-          {/* 7: 증거 제출 여부 확인 */}
-          {typeof complaintId === 'number' &&
-            Number.isFinite(complaintId) &&
-            complaintId > 0 &&
-            step === 7 && <EvidenceInfoSection ref={evidenceRef} />}
         </div>
         {/* 8: 실제 채팅창 + 오른쪽 메타 패널 */}
         {typeof complaintId === 'number' &&
           Number.isFinite(complaintId) &&
           complaintId > 0 &&
-          step === 8 && (
-            <div className="flex flex-1 gap-2">
-              <div className="flex flex-1">
+          step === 6 && (
+            <div className="flex min-h-0 flex-1 gap-4">
+              <div className="flex min-h-0 flex-1">
                 <ChatWindowSection
                   complaintId={complaintId}
                   mode={chatMode}
                   initialAiSessionId={initialAiSessionIdFromState ?? null}
                   onInitStart={() => setRagSearchStarted(true)}
-                  onComplete={() => setIsChatCompleted(true)}
+                  onComplete={() => {
+                    setIsChatCompleted(true);
+                    // 자동으로 다음 단계로 이동
+                    setTimeout(() => handleNext(), 1500);
+                  }}
                   onInitMeta={({ offense, rag_keyword, rag_cases }) => {
                     console.log('📌 onInitMeta in Wizard:', {
                       offense,
@@ -382,67 +361,225 @@ const ComplaintWizardPage: React.FC = () => {
                 />
               </div>
 
-              <aside className="rounded-200 bg-neutral-0 mt-2 h-[498px] w-[340px] border border-neutral-200 p-4 xl:h-[576px]">
-                <h2 className="text-body-1-bold mb-2">AI가 찾은 핵심 키워드</h2>
-                <p className="text-body-3-regular mb-4 text-neutral-700">
-                  {ragKeyword
-                    ? `"${ragKeyword}"`
-                    : '사건 개요를 입력하면, AI가 핵심 키워드를 분석해서 보여드려요.'}
-                </p>
+              <aside className="flex min-h-0 w-[340px] shrink-0 flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+                {/* 헤더 */}
+                <div className="flex items-center gap-2 border-b border-neutral-100 px-5 py-3">
+                  <div className="bg-primary-100 flex h-7 w-7 items-center justify-center rounded-full">
+                    <span
+                      className="material-symbols-outlined text-primary-400"
+                      style={{ fontSize: '16px' }}
+                    >
+                      search
+                    </span>
+                  </div>
+                  <h2 className="text-body-3-bold text-neutral-800">AI 분석 결과</h2>
+                </div>
 
-                {ragKeyword && (
-                  <>
-                    <h3 className="text-body-2-bold mb-1">검색 기준</h3>
-                    <p className="text-body-3-regular mb-3 text-neutral-600">
-                      유사 판례는 "{ragKeyword}"를 중심으로 검색했어요.
-                    </p>
-                  </>
-                )}
-
-                <h3 className="text-body-2-bold mb-2">유사 판례</h3>
-
-                {ragCases.length === 0 ? (
-                  ragSearchStarted ? (
-                    <p className="animate-wave-fill inline-block">유사 판례를 찾고 있어요...</p>
+                {/* 키워드 섹션 */}
+                <div className="border-b border-neutral-100 px-5 py-4">
+                  <p className="text-detail-regular mb-2 text-neutral-400">핵심 키워드</p>
+                  {ragKeyword ? (
+                    <span className="bg-primary-0 text-body-3-bold text-primary-500 inline-flex items-center gap-1.5 rounded-full px-3 py-1.5">
+                      <span
+                        className="material-symbols-outlined"
+                        style={{ fontSize: '16px' }}
+                      >
+                        tag
+                      </span>
+                      {ragKeyword}
+                    </span>
                   ) : (
-                    <p className="text-caption-regular text-neutral-500">
-                      아직 불러온 판례가 없어요. 사건 개요를 입력하면 관련 판례를 보여드릴게요.
+                    <p className="text-body-3-regular text-neutral-400">
+                      사건 개요를 입력하면 AI가 분석해드려요
                     </p>
-                  )
-                ) : (
-                  <ul className="flex flex-col gap-3">
-                    {ragCases.map((c, idx) => (
-                      <li key={c.case_no || idx}>
-                        <button
-                          type="button"
-                          onClick={() => setSelectedCase(c)}
-                          className={[
-                            'rounded-200 bg-neutral-0 w-full border border-neutral-200 px-3 py-2',
-                            'flex items-center justify-between gap-3',
-                            'hover:border-primary-100 hover:bg-primary-25/40',
-                            'transition-colors duration-200',
-                          ].join(' ')}
-                        >
-                          <div className="flex flex-col text-left">
-                            <span className="text-caption-regular text-neutral-500">사건 번호</span>
-                            <span className="text-body-4-bold text-neutral-900">{c.case_no}</span>
-                          </div>
-                          <div className="flex flex-col items-end gap-1">
-                            <span className="text-detail-regular text-primary-600 mt-1 inline-flex items-center gap-1">
-                              자세히 보기
-                              <span
-                                className="material-symbols-outlined"
-                                style={{ fontSize: '16px' }}
+                  )}
+                </div>
+
+                {/* 유사 판례 */}
+                <div className="flex flex-1 flex-col overflow-hidden px-5 py-4">
+                  <div className="mb-3 flex items-center justify-between">
+                    <p className="text-detail-regular text-neutral-400">유사 판례</p>
+                    {ragCases.length > 0 && (
+                      <span className="text-detail-bold text-primary-400">{ragCases.length}건</span>
+                    )}
+                  </div>
+
+                  <div className="balaw-scrollbar flex-1 overflow-y-auto">
+                    {ragCases.length === 0 ? (
+                      <div className="flex flex-col items-center justify-center py-8 text-center">
+                        {ragSearchStarted ? (
+                          <>
+                            {/* 책 넘기기 애니메이션 */}
+                            <div
+                              className="relative mb-3 h-12 w-16"
+                              style={{ perspective: '400px' }}
+                            >
+                              {/* 책 전체를 비스듬히 기울임 */}
+                              <div
+                                className="absolute inset-0"
+                                style={{
+                                  transform: 'rotateX(20deg) rotateZ(-5deg)',
+                                  transformStyle: 'preserve-3d',
+                                }}
                               >
-                                open_in_new
-                              </span>
+                                {/* 책 뒤표지 */}
+                                <div className="bg-primary-300 absolute inset-0 rounded-r-sm shadow-sm" />
+                                {/* 책 옆면 (두께) */}
+                                <div className="bg-primary-400 absolute top-0 left-0 h-full w-1 rounded-l-sm" />
+                                {/* 페이지 3 */}
+                                <div
+                                  className="animate-book-page-3 bg-primary-50 absolute inset-0 rounded-r-sm shadow-sm"
+                                  style={{
+                                    transformOrigin: 'left center',
+                                    backfaceVisibility: 'hidden',
+                                  }}
+                                >
+                                  <div className="mx-2 mt-2 space-y-1">
+                                    <div className="h-[2px] w-3/4 rounded bg-neutral-200" />
+                                    <div className="h-[2px] w-1/2 rounded bg-neutral-200" />
+                                  </div>
+                                </div>
+                                {/* 페이지 2 */}
+                                <div
+                                  className="animate-book-page-2 bg-primary-0 absolute inset-0 rounded-r-sm shadow-sm"
+                                  style={{
+                                    transformOrigin: 'left center',
+                                    backfaceVisibility: 'hidden',
+                                  }}
+                                >
+                                  <div className="mx-2 mt-2 space-y-1">
+                                    <div className="h-[2px] w-2/3 rounded bg-neutral-200" />
+                                    <div className="h-[2px] w-4/5 rounded bg-neutral-200" />
+                                  </div>
+                                </div>
+                                {/* 페이지 1 (맨 위) */}
+                                <div
+                                  className="animate-book-page-1 absolute inset-0 rounded-r-sm bg-white shadow-sm"
+                                  style={{
+                                    transformOrigin: 'left center',
+                                    backfaceVisibility: 'hidden',
+                                  }}
+                                >
+                                  <div className="mx-2 mt-2 space-y-1">
+                                    <div className="h-[2px] w-1/2 rounded bg-neutral-300" />
+                                    <div className="h-[2px] w-3/4 rounded bg-neutral-200" />
+                                    <div className="h-[2px] w-2/3 rounded bg-neutral-200" />
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <p className="text-body-3-regular text-neutral-500">
+                              유사 판례를 찾고 있어요...
+                            </p>
+                          </>
+                        ) : (
+                          <>
+                            <span
+                              className="material-symbols-outlined mb-2 text-neutral-300"
+                              style={{ fontSize: '28px' }}
+                            >
+                              gavel
                             </span>
-                          </div>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
+                            <p className="text-body-3-regular text-neutral-400">
+                              아직 불러온 판례가 없어요
+                            </p>
+                            <p className="text-detail-regular mt-1 text-neutral-300">
+                              사건 개요를 입력하면 관련 판례를 보여드릴게요
+                            </p>
+                          </>
+                        )}
+                      </div>
+                    ) : (
+                      <ul className="flex flex-col gap-3">
+                        {ragCases.map((c, idx) => {
+                          const isOpen = selectedCase?.case_no === c.case_no;
+
+                          return (
+                            <li key={c.case_no || idx}>
+                              <div
+                                className={[
+                                  'w-full rounded-xl border bg-neutral-50 transition-all duration-300',
+                                  isOpen
+                                    ? 'border-primary-200 bg-primary-0/20'
+                                    : 'border-neutral-200',
+                                ].join(' ')}
+                              >
+                                {/* 카드 헤더 (클릭 가능) */}
+                                <button
+                                  type="button"
+                                  onClick={() => setSelectedCase(isOpen ? null : c)}
+                                  className="group flex w-full items-center justify-between px-4 py-3 text-left"
+                                >
+                                  <div className="flex flex-col gap-0.5">
+                                    <span className="text-body-3-bold text-neutral-800">
+                                      {c.case_no}
+                                    </span>
+                                    {c.label && (
+                                      <span className="text-detail-regular text-neutral-500">
+                                        {c.label}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <span
+                                    className={[
+                                      'material-symbols-outlined text-neutral-400 transition-transform duration-300',
+                                      isOpen ? 'rotate-180' : '',
+                                    ].join(' ')}
+                                    style={{ fontSize: '18px' }}
+                                  >
+                                    expand_more
+                                  </span>
+                                </button>
+
+                                {/* 펼쳐지는 상세 영역 */}
+                                <div
+                                  className="grid transition-[grid-template-rows] duration-300 ease-out"
+                                  style={{ gridTemplateRows: isOpen ? '1fr' : '0fr' }}
+                                >
+                                  <div className="overflow-hidden">
+                                    <div className="border-t border-neutral-100 px-4 pt-3 pb-4">
+                                      {/* 유사 포인트 */}
+                                      {c.similarity && (
+                                        <div className="mb-3">
+                                          <p className="text-detail-regular mb-1 text-neutral-400">
+                                            유사 포인트
+                                          </p>
+                                          <p className="text-detail-regular leading-relaxed text-neutral-700">
+                                            {c.similarity}
+                                          </p>
+                                        </div>
+                                      )}
+
+                                      {/* 사건 개요 */}
+                                      <div className="mb-3">
+                                        <p className="text-detail-regular mb-1 text-neutral-400">
+                                          사건 개요
+                                        </p>
+                                        <p className="text-detail-regular leading-relaxed whitespace-pre-line text-neutral-700">
+                                          {c.summary || '요약 정보가 없어요.'}
+                                        </p>
+                                      </div>
+
+                                      {/* 판결 결과 */}
+                                      <div>
+                                        <p className="text-detail-regular mb-1 text-neutral-400">
+                                          판결 결과
+                                        </p>
+                                        <p className="text-detail-regular leading-relaxed whitespace-pre-line text-neutral-700">
+                                          {c.result || '판결 결과 정보가 없어요.'}
+                                        </p>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
+                </div>
               </aside>
             </div>
           )}
@@ -450,52 +587,58 @@ const ComplaintWizardPage: React.FC = () => {
         {typeof complaintId === 'number' &&
           Number.isFinite(complaintId) &&
           complaintId > 0 &&
-          step === 9 &&
+          step === 7 &&
           generatedComplaint && (
-            <ComplaintPreviewSection
-              complaintId={complaintId}
-              content={generatedComplaint}
-            />
+            <div className="flex min-h-0 flex-1 flex-col">
+              <ComplaintPreviewSection
+                complaintId={complaintId}
+                content={generatedComplaint}
+              />
+            </div>
           )}
         {/* 10: DOCX 다운로드 섹션 */}
         {typeof complaintId === 'number' &&
           Number.isFinite(complaintId) &&
           complaintId > 0 &&
-          step === 10 && <ComplaintDownloadSection complaintId={complaintId} />}
-        <WizardNavButtons
-          onPrev={prev}
-          onNext={handleNext}
-          isNextDisabled={isGenerating || (step === 8 && !isChatCompleted)}
-          disablePrev={step === 0 || step === 8 || step === 9}
-          nextLabel={
-            step === 10 ? '종료' : step === 8 && isGenerating ? '고소장 작성 중...' : '다음'
-          }
-        />
+          step === 8 && (
+            <div className="flex min-h-0 flex-1 flex-col">
+              <ComplaintDownloadSection complaintId={complaintId} />
+            </div>
+          )}
+        {step !== 6 && (
+          <WizardNavButtons
+            onPrev={prev}
+            onNext={handleNext}
+            isNextDisabled={
+              isGenerating || (step === 0 && entryMode === null) || (step === 1 && !allChecked)
+            }
+            disablePrev={step === 0 || step === 7}
+            nextLabel={step === 8 ? '종료' : '다음'}
+          />
+        )}
         <GeneratingModal open={showGeneratingModal} />
       </main>
       <Footer />
 
-      {/* 판례 상세 모달 */}
-      {selectedCase && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4">
-          <CaseDetailModal
-            ragCase={selectedCase}
-            onClose={() => setSelectedCase(null)}
-          />
-        </div>
-      )}
-
       {showExitModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4">
-          <CharacterModal
-            variant="exit"
-            onCancel={() => setShowExitModal(false)}
-            onConfirm={() => {
-              setShowExitModal(false);
-              resetWizard();
-              navigate('/');
-            }}
-          />
+        <div
+          className="animate-overlay-in fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4"
+          onClick={() => setShowExitModal(false)}
+        >
+          <div
+            className="animate-pop-in"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CharacterModal
+              variant="exit"
+              onCancel={() => setShowExitModal(false)}
+              onConfirm={() => {
+                setShowExitModal(false);
+                resetWizard();
+                navigate('/');
+              }}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/features/complaint/sections/AccusedExtraInfoSection.tsx
+++ b/src/features/complaint/sections/AccusedExtraInfoSection.tsx
@@ -4,7 +4,6 @@ import DaumPostcodeButton from '@/shared/ui/DaumPostcodeButton';
 import type { DaumPostcodeResult } from '@/shared/ui/DaumPostcodeButton';
 import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import IntroHeader from '@/shared/ui/IntroHeader';
-import { splitAddressTo3FromString } from '@/shared/utils/krContact';
 
 // 피고소인 추가 정보 타입
 export type AccusedExtraInfo = {
@@ -28,11 +27,9 @@ const AccusedExtraInfoSection = forwardRef<AccusedExtraInfoSectionHandle, Props>
 
   // 입력값 상태
   const [occupation, setOccupation] = useState('');
-
   const [officeAddr1, setOfficeAddr1] = useState('');
   const [officeAddr2, setOfficeAddr2] = useState('');
   const [officeAddr3, setOfficeAddr3] = useState('');
-
   const [etc, setEtc] = useState('');
 
   // 모름 토글
@@ -41,33 +38,18 @@ const AccusedExtraInfoSection = forwardRef<AccusedExtraInfoSectionHandle, Props>
 
   // 에러
   const [err, setErr] = useState<string | null>(null);
-
-  // 주소가 주소 찾기로 한 번이라도 세팅된 적 있는지
   const [hasAddress, setHasAddress] = useState(false);
 
-  // 주소 필드 클릭 시: 아직 검색 안했으면 에러만 보여주기
-  const handleAddressFieldClick = () => {
-    // "모름"이면 그냥 아무것도 하지 않음
-    if (unknownOfficeAddress) return;
-
-    // 주소가 비어 있고, 주소 찾기도 안 한 상태면 에러
-    if (!hasAddress && !officeAddr1 && !officeAddr2 && !officeAddr3) {
-      setErr('주소 찾기 버튼을 눌러 주소를 검색해주세요.');
-    }
-  };
-
-  // 주소 선택 콜백 (다음 API에서 선택되면 호출)
+  // 주소 선택 콜백
   const handleAddressSelect = (data: DaumPostcodeResult) => {
-    const { a1, a2, a3 } = splitAddressTo3FromString(data.roadAddress);
-    setOfficeAddr1(a1);
-    setOfficeAddr2(a2);
-    setOfficeAddr3(a3);
+    setOfficeAddr1(data.sido);
+    setOfficeAddr2(data.sigungu);
+    setOfficeAddr3(data.bname);
     setHasAddress(true);
     setUnknownOfficeAddress(false);
     setErr(null);
   };
 
-  // 공통 라벨 렌더러 (고소인 섹션과 동일 스타일)
   const renderLabel = (text: string, required: boolean) => {
     const labelText = required ? '(필수)' : '(선택)';
     return (
@@ -86,13 +68,20 @@ const AccusedExtraInfoSection = forwardRef<AccusedExtraInfoSectionHandle, Props>
     );
   };
 
-  // 사무실 주소 문자열
   const officeAddress = useMemo(() => {
     if (unknownOfficeAddress) return '';
     return [officeAddr1, officeAddr2, officeAddr3].filter(Boolean).join(' ').trim();
   }, [officeAddr1, officeAddr2, officeAddr3, unknownOfficeAddress]);
 
-  // 최종 객체 만들기 (유효성 검사는 안 하고 그대로 넘김)
+  const handleCheckboxChange = (
+    checked: boolean,
+    setFlag: React.Dispatch<React.SetStateAction<boolean>>,
+    ...setters: React.Dispatch<React.SetStateAction<string>>[]
+  ) => {
+    setFlag(checked);
+    if (checked) setters.forEach((setter) => setter(''));
+  };
+
   const buildExtraInfo = (): AccusedExtraInfo => {
     if (!unknownOccupation && !occupation.trim()) {
       const msg = '직업을 입력하거나 "모름"을 선택해주세요.';
@@ -116,26 +105,15 @@ const AccusedExtraInfoSection = forwardRef<AccusedExtraInfoSectionHandle, Props>
     };
   };
 
-  // 모름 체크 핸들러
-  const handleCheckboxChange = (
-    checked: boolean,
-    setFlag: React.Dispatch<React.SetStateAction<boolean>>,
-    ...setters: React.Dispatch<React.SetStateAction<string>>[]
-  ) => {
-    setFlag(checked);
-    if (checked) setters.forEach((setter) => setter(''));
-  };
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     try {
       buildExtraInfo();
     } catch {
-      // 에러 메시지는 이미 setErr로 처리됨
+      // setErr로 처리됨
     }
   };
 
-  // 외부에서 save() 호출 가능하게
   useImperativeHandle(ref, () => ({
     save: async () => {
       const info = buildExtraInfo();
@@ -145,18 +123,12 @@ const AccusedExtraInfoSection = forwardRef<AccusedExtraInfoSectionHandle, Props>
 
   return (
     <section
-      className={[
-        'flex flex-col items-center justify-between',
-        'h-[600px] w-full max-w-[1000px]',
-        'pb-6',
-        'bg-neutral-0',
-      ].join(' ')}
+      className={['flex flex-col items-center', 'w-full flex-1', 'pb-6', 'bg-neutral-0'].join(' ')}
     >
       <IntroHeader
         title="고소장 작성하기"
         lines={[
-          '피고소인의 직업이나 사무실 정보 등을 알고 있다면',
-          '아래에 추가로 작성해주세요.',
+          '피고소인의 직업이나 사무실 정보 등을 알고 있다면 아래에 추가로 작성해주세요.',
           '모르시는 항목은 비워두셔도 괜찮아요.',
         ]}
         center
@@ -166,170 +138,95 @@ const AccusedExtraInfoSection = forwardRef<AccusedExtraInfoSectionHandle, Props>
       <form
         ref={formRef}
         onSubmit={handleSubmit}
-        className="mt-6 flex w-[420px] flex-col gap-5"
+        className="mt-2 flex w-full flex-1 flex-col justify-center gap-5"
       >
-        <div className="flex flex-1 flex-col justify-center gap-5 px-5">
-          {/* 직업 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('직업', true)}
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                work
-              </span>
-
+        {/* 입력 필드 카드 */}
+        <div className="flex flex-1 items-center justify-center">
+          <div className="rounded-300 w-full max-w-[520px] border border-neutral-200 bg-white shadow-sm">
+            {/* 직업 */}
+            <div className="flex flex-col gap-2 border-b border-neutral-100 px-5 py-4">
+              <div className="flex items-center justify-between">
+                {renderLabel('직업', true)}
+                <label className="text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 cursor-pointer"
+                    checked={unknownOccupation}
+                    onChange={(e) =>
+                      handleCheckboxChange(e.target.checked, setUnknownOccupation, setOccupation)
+                    }
+                  />
+                  모름
+                </label>
+              </div>
               <input
                 disabled={unknownOccupation}
                 value={occupation}
                 onChange={(e) => setOccupation(e.target.value)}
                 className={[
-                  'rounded-200 h-10 flex-1 px-3',
+                  'rounded-200 h-10 w-full px-3',
                   'border border-neutral-300',
                   'disabled:bg-neutral-100 disabled:text-neutral-400',
-                  'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
+                  'focus:border-primary-400 focus:ring-primary-400 outline-none focus:ring-2',
                 ].join(' ')}
-                placeholder={unknownOccupation ? '모름' : '이름 입력'}
+                placeholder={unknownOccupation ? '모름' : '예: 회사원, 자영업자 등'}
                 type="text"
               />
+            </div>
 
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
-                  checked={unknownOccupation}
-                  onChange={(e) =>
-                    handleCheckboxChange(e.target.checked, setUnknownOccupation, setOccupation)
+            {/* 사무실 주소 */}
+            <div className="flex flex-col gap-2 border-b border-neutral-100 px-5 py-4">
+              <div className="flex items-center justify-between">
+                {renderLabel('사무실 주소', true)}
+                <label className="text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 cursor-pointer"
+                    checked={unknownOfficeAddress}
+                    onChange={(e) => {
+                      handleCheckboxChange(
+                        e.target.checked,
+                        setUnknownOfficeAddress,
+                        setOfficeAddr1,
+                        setOfficeAddr2,
+                        setOfficeAddr3,
+                      );
+                      if (e.target.checked) {
+                        setErr(null);
+                        setHasAddress(false);
+                      }
+                    }}
+                  />
+                  모름
+                </label>
+              </div>
+              {unknownOfficeAddress ? (
+                <div className="rounded-200 flex h-10 w-full items-center border border-neutral-300 bg-neutral-100 px-3 text-neutral-400">
+                  모름
+                </div>
+              ) : (
+                <DaumPostcodeButton
+                  onSelect={handleAddressSelect}
+                  address={
+                    hasAddress
+                      ? { city: officeAddr1, district: officeAddr2, town: officeAddr3 }
+                      : undefined
                   }
                 />
-                모름
-              </label>
+              )}
             </div>
-          </div>
 
-          {/* 사무실 주소 */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              {/* 주소 라벨 */}
-              {renderLabel('사무실 주소', true)}
-
-              {/* 주소 검색 버튼 */}
-              <DaumPostcodeButton onSelect={handleAddressSelect} />
-            </div>
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                location_city
-              </span>
-
-              <div className="grid w-full grid-cols-3 gap-2">
-                <input
-                  disabled={unknownOfficeAddress}
-                  value={officeAddr1}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficeAddress ? '모름' : '시/도'}
-                  type="text"
-                />
-                <input
-                  disabled={unknownOfficeAddress}
-                  value={officeAddr2}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficeAddress ? '모름' : '시/군/구'}
-                  type="text"
-                />
-                <input
-                  disabled={unknownOfficeAddress}
-                  value={officeAddr3}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficeAddress ? '모름' : '읍/면/동'}
-                  type="text"
-                />
-              </div>
-
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
-                  checked={unknownOfficeAddress}
-                  onChange={(e) => {
-                    const checked = e.target.checked;
-
-                    handleCheckboxChange(
-                      checked,
-                      setUnknownOfficeAddress,
-                      setOfficeAddr1,
-                      setOfficeAddr2,
-                      setOfficeAddr3,
-                    );
-
-                    if (checked) {
-                      // "주소 모름"으로 바꾸면 주소 관련 에러는 지워준다
-                      setErr(null);
-                      setHasAddress(false); // 선택사항: 모름이면 hasAddress도 false로
-                    }
-                  }}
-                />
-                모름
-              </label>
-            </div>
-          </div>
-
-          {/* 기타 정보 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('기타 정보', false)}
-            <div className="flex items-start gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50 mt-1"
-                style={{ fontSize: '24px' }}
-              >
-                info
-              </span>
-
+            {/* 기타 정보 */}
+            <div className="flex flex-col gap-2 px-5 py-4">
+              {renderLabel('기타 정보', false)}
               <textarea
                 value={etc}
                 onChange={(e) => setEtc(e.target.value)}
                 className={[
-                  'rounded-200 flex-1 px-3 py-2',
+                  'rounded-200 w-full px-3 py-2',
                   'border border-neutral-300',
                   'min-h-[120px] resize-y',
-                  'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
+                  'focus:border-primary-400 focus:ring-primary-400 outline-none focus:ring-2',
                 ].join(' ')}
                 placeholder="피고소인의 계좌 번호, 피고소인과의 관계 등 피고소인을 특정할 수 있는 정보를 알려주세요."
               />

--- a/src/features/complaint/sections/AccusedInfoSection.tsx
+++ b/src/features/complaint/sections/AccusedInfoSection.tsx
@@ -1,13 +1,20 @@
-import React, { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import DaumPostcodeButton from '@/shared/ui/DaumPostcodeButton';
 import type { DaumPostcodeResult } from '@/shared/ui/DaumPostcodeButton';
 import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import IntroHeader from '@/shared/ui/IntroHeader';
-import { splitAddressTo3FromString } from '@/shared/utils/krContact';
 
-// 부모에서 사용할 타입
-export type AccusedBasicInfo = {
+// 통합 타입
+export type AccusedFullInfo = {
+  // basic
   name: string;
   email: string;
   address: string | null;
@@ -16,11 +23,20 @@ export type AccusedBasicInfo = {
   unknownEmail: boolean;
   unknownAddr: boolean;
   unknownPhone: boolean;
+  // extra
+  occupation: string;
+  officeAddress: string;
+  etc: string;
+  unknownOccupation: boolean;
+  unknownOfficeAddress: boolean;
 };
+
+// 하위 호환
+export type AccusedBasicInfo = AccusedFullInfo;
 
 // 외부에서 save()를 호출할 수 있도록 노출
 export type AccusedInfoSectionHandle = {
-  save: () => Promise<AccusedBasicInfo>;
+  save: () => Promise<AccusedFullInfo>;
 };
 
 type Props = {
@@ -28,70 +44,122 @@ type Props = {
 };
 
 const AccusedInfoSection = forwardRef<AccusedInfoSectionHandle, Props>(({ complaintId }, ref) => {
-  // 입력값
+  // === 기본 정보 ===
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [addr1, setAddr1] = useState('');
   const [addr2, setAddr2] = useState('');
   const [addr3, setAddr3] = useState('');
-  const [p1, setP1] = useState('');
-  const [p2, setP2] = useState('');
-  const [p3, setP3] = useState('');
+  const [phone, setPhone] = useState('');
 
-  // 모름 토글
   const [unknownName, setUnknownName] = useState(false);
   const [unknownEmail, setUnknownEmail] = useState(false);
   const [unknownAddr, setUnknownAddr] = useState(false);
   const [unknownPhone, setUnknownPhone] = useState(false);
 
-  // UI
-  const [err, setErr] = useState<string | null>(null);
+  // === 추가 정보 ===
+  const [occupation, setOccupation] = useState('');
+  const [officeAddr1, setOfficeAddr1] = useState('');
+  const [officeAddr2, setOfficeAddr2] = useState('');
+  const [officeAddr3, setOfficeAddr3] = useState('');
+  const [etc, setEtc] = useState('');
 
-  const formRef = useRef<HTMLFormElement>(null);
+  const [unknownOccupation, setUnknownOccupation] = useState(false);
+  const [unknownOfficeAddress, setUnknownOfficeAddress] = useState(false);
 
-  // 주소가 주소 찾기로 한 번이라도 세팅된 적 있는지
-  const [hasAddress, setHasAddress] = useState(false);
+  // 전체 정보 없음 토글
+  const allBasicUnknown = unknownName && unknownEmail && unknownAddr && unknownPhone;
+  const allExtraUnknown = unknownOccupation && unknownOfficeAddress;
 
-  // 주소 필드 클릭 시: 아직 검색 안했으면 에러만 보여주기
-  const handleAddressFieldClick = () => {
-    // "모름"이면 그냥 아무것도 하지 않음
-    if (unknownAddr) return;
-
-    // 주소가 비어 있고, 주소 찾기도 안 한 상태면 에러
-    if (!hasAddress && !addr1 && !addr2 && !addr3) {
-      setErr('주소 찾기 버튼을 눌러 주소를 검색해주세요.');
+  const handleToggleAllBasic = (checked: boolean) => {
+    setUnknownName(checked);
+    setUnknownEmail(checked);
+    setUnknownAddr(checked);
+    setUnknownPhone(checked);
+    if (checked) {
+      setName('');
+      setEmail('');
+      setAddr1('');
+      setAddr2('');
+      setAddr3('');
+      setPhone('');
+      setHasAddress(false);
     }
   };
 
-  // 주소 선택 콜백 (다음 API에서 선택되면 호출)
+  const handleToggleAllExtra = (checked: boolean) => {
+    setUnknownOccupation(checked);
+    setUnknownOfficeAddress(checked);
+    if (checked) {
+      setOccupation('');
+      setOfficeAddr1('');
+      setOfficeAddr2('');
+      setOfficeAddr3('');
+      setHasOfficeAddress(false);
+    }
+  };
+
+  // UI
+  const [err, setErr] = useState<string | null>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const [hasAddress, setHasAddress] = useState(false);
+  const [hasOfficeAddress, setHasOfficeAddress] = useState(false);
+
+  // 주소 선택 콜백
   const handleAddressSelect = (data: DaumPostcodeResult) => {
-    const { a1, a2, a3 } = splitAddressTo3FromString(data.roadAddress);
-    setAddr1(a1);
-    setAddr2(a2);
-    setAddr3(a3);
+    setAddr1(data.sido);
+    setAddr2(data.sigungu);
+    setAddr3(data.bname);
     setHasAddress(true);
-    setUnknownAddr(false); // 검색하면 모름 자동 해제
+    setUnknownAddr(false);
     setErr(null);
   };
 
-  // 공통 라벨 렌더러 (고소인 섹션과 동일 스타일)
-  const renderLabel = (text: string, required: boolean) => {
-    const labelText = required ? '(필수)' : '(선택)';
-    return (
-      <label className="text-body-3-regular text-neutral-900">
-        <span
-          className={
-            required
-              ? 'text-detail-bold text-positive-200 mr-4'
-              : 'text-detail-bold mr-2 text-neutral-500'
-          }
-        >
-          {labelText}
-        </span>
-        {text}
-      </label>
-    );
+  const handleOfficeAddressSelect = (data: DaumPostcodeResult) => {
+    setOfficeAddr1(data.sido);
+    setOfficeAddr2(data.sigungu);
+    setOfficeAddr3(data.bname);
+    setHasOfficeAddress(true);
+    setUnknownOfficeAddress(false);
+    setErr(null);
   };
+
+  // 전화번호 포맷팅
+  const formatPhone = (value: string) => {
+    const digits = value.replace(/\D/g, '').slice(0, 11);
+    if (digits.length <= 3) return digits;
+    if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  };
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPhone(formatPhone(e.target.value));
+  };
+
+  const phoneDigits = phone.replace(/\D/g, '');
+
+  // 입력값 변경 시 에러 자동 해제
+  useEffect(() => {
+    if (err) setErr(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    name,
+    email,
+    phone,
+    addr1,
+    occupation,
+    officeAddr1,
+    etc,
+    unknownName,
+    unknownEmail,
+    unknownAddr,
+    unknownPhone,
+    unknownOccupation,
+    unknownOfficeAddress,
+  ]);
+
+  // 라벨 렌더러
 
   // 주소 문자열
   const address = useMemo(() => {
@@ -99,37 +167,60 @@ const AccusedInfoSection = forwardRef<AccusedInfoSectionHandle, Props>(({ compla
     return [addr1, addr2, addr3].filter(Boolean).join(' ').trim();
   }, [addr1, addr2, addr3, unknownAddr]);
 
-  // 전화번호 문자열
-  const phone = useMemo(() => {
-    if (unknownPhone) return '';
-    if (!p1 && !p2 && !p3) return '';
-    return [p1, p2, p3].join('-').replace(/--+/g, '-');
-  }, [p1, p2, p3, unknownPhone]);
+  const officeAddress = useMemo(() => {
+    if (unknownOfficeAddress) return '';
+    return [officeAddr1, officeAddr2, officeAddr3].filter(Boolean).join(' ').trim();
+  }, [officeAddr1, officeAddr2, officeAddr3, unknownOfficeAddress]);
 
-  // 유효성 검사 + 최종 객체 만들기
-  const buildBasicInfo = (): AccusedBasicInfo => {
+  const phoneValue = useMemo(() => {
+    if (unknownPhone) return '';
+    return phoneDigits;
+  }, [phoneDigits, unknownPhone]);
+
+  // 정보 없음 체크 핸들러
+  const handleCheckboxChange = (
+    checked: boolean,
+    setFlag: React.Dispatch<React.SetStateAction<boolean>>,
+    ...setters: React.Dispatch<React.SetStateAction<string>>[]
+  ) => {
+    setFlag(checked);
+    if (checked) setters.forEach((setter) => setter(''));
+  };
+
+  // 유효성 검사 + 객체 빌드
+  const buildFullInfo = (): AccusedFullInfo => {
     if (!Number.isFinite(complaintId) || complaintId <= 0) {
       const msg = '잘못된 고소장 ID입니다.';
       setErr(msg);
       throw new Error(msg);
     }
     if (!unknownName && !name.trim()) {
-      const msg = '이름을 입력하거나 "모름"을 선택해주세요.';
+      const msg = '이름을 입력하거나 "정보 없음"을 선택해주세요.';
       setErr(msg);
       throw new Error(msg);
     }
     if (!unknownEmail && !email.trim()) {
-      const msg = '이메일을 입력하거나 "모름"을 선택해주세요.';
+      const msg = '이메일을 입력하거나 "정보 없음"을 선택해주세요.';
       setErr(msg);
       throw new Error(msg);
     }
     if (!unknownAddr && !address) {
-      const msg = '주소를 입력하거나 "모름"을 선택해주세요.';
+      const msg = '주소를 입력하거나 "정보 없음"을 선택해주세요.';
       setErr(msg);
       throw new Error(msg);
     }
-    if (!unknownPhone && (!p1 || !p2 || !p3)) {
-      const msg = '연락처를 입력하거나 "모름"을 선택해주세요.';
+    if (!unknownPhone && phoneDigits.length < 10) {
+      const msg = '연락처를 입력하거나 "정보 없음"을 선택해주세요.';
+      setErr(msg);
+      throw new Error(msg);
+    }
+    if (!unknownOccupation && !occupation.trim()) {
+      const msg = '직업을 입력하거나 "정보 없음"을 선택해주세요.';
+      setErr(msg);
+      throw new Error(msg);
+    }
+    if (!unknownOfficeAddress && !officeAddress.trim()) {
+      const msg = '사무실 주소를 입력하거나 "정보 없음"을 선택해주세요.';
       setErr(msg);
       throw new Error(msg);
     }
@@ -140,56 +231,44 @@ const AccusedInfoSection = forwardRef<AccusedInfoSectionHandle, Props>(({ compla
       name: unknownName ? ' ' : name.trim(),
       email: unknownEmail ? ' ' : email.trim(),
       address: unknownAddr ? null : address,
-      phone: unknownPhone ? ' ' : phone,
+      phone: unknownPhone ? ' ' : phoneValue,
       unknownName,
       unknownEmail,
       unknownAddr,
       unknownPhone,
+      occupation: unknownOccupation ? ' ' : occupation.trim(),
+      officeAddress: unknownOfficeAddress ? ' ' : officeAddress.trim(),
+      etc: etc.trim(),
+      unknownOccupation,
+      unknownOfficeAddress,
     };
-  };
-
-  // 모름 체크 핸들러
-  const handleCheckboxChange = (
-    checked: boolean,
-    setFlag: React.Dispatch<React.SetStateAction<boolean>>,
-    ...setters: React.Dispatch<React.SetStateAction<string>>[]
-  ) => {
-    setFlag(checked);
-    if (checked) setters.forEach((setter) => setter(''));
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      buildBasicInfo();
+      buildFullInfo();
     } catch {
       // 에러 메시지는 이미 setErr로 처리됨
     }
   };
 
-  // 외부에서 save() 호출 가능하게
   useImperativeHandle(ref, () => ({
     save: async () => {
-      const info = buildBasicInfo();
+      const info = buildFullInfo();
       return info;
     },
   }));
 
   return (
     <section
-      className={[
-        'flex flex-col items-center justify-between',
-        'h-[600px] w-full max-w-[1000px]',
-        'pb-6',
-        'bg-neutral-0',
-      ].join(' ')}
+      className={['flex flex-col items-center', 'w-full flex-1', 'pb-6', 'bg-neutral-0'].join(' ')}
     >
       <IntroHeader
         title="고소장 작성하기"
         lines={[
-          '상대방에 대한 기본 정보를 작성해주세요.',
-          '알고 있는 범위 내에서만',
-          '상대방 정보를 작성해도 괜찮아요.',
+          '상대방에 대한 정보를 작성해주세요.',
+          '알고 있는 범위 내에서만 상대방 정보를 작성해도 괜찮아요.',
         ]}
         center
         showArrow
@@ -198,257 +277,312 @@ const AccusedInfoSection = forwardRef<AccusedInfoSectionHandle, Props>(({ compla
       <form
         ref={formRef}
         onSubmit={handleSubmit}
-        className="mt-6 flex w-[420px] flex-col gap-5"
+        className="mt-2 flex w-full flex-1 flex-col items-center justify-center gap-6"
       >
-        {/* 입력 필드들 */}
-        <div className="flex flex-1 flex-col justify-center gap-5 px-5">
-          {/* 이름 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('이름', true)}
-            <div className="flex items-center gap-3">
+        {/* ID 카드 미리보기 */}
+        <div className="w-full max-w-[520px]">
+          <div className="overflow-hidden rounded-2xl border border-neutral-300 bg-gradient-to-br from-neutral-50 to-white shadow-sm">
+            <div className="flex items-center gap-2 bg-neutral-700 px-5 py-2.5">
               <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
+                className="material-symbols-outlined text-white/80"
+                style={{ fontSize: '16px' }}
               >
-                person
+                person_search
               </span>
+              <span className="text-detail-bold text-white/90">피고소인 정보</span>
+            </div>
+            {/* Top row: basic */}
+            <div className="grid grid-cols-2 gap-x-6 gap-y-3 px-5 py-4">
+              <div>
+                <p className="text-detail-regular text-neutral-400">이름</p>
+                <p
+                  className={`text-body-3-bold transition-colors ${unknownName ? 'text-neutral-300 italic' : name ? 'text-neutral-900' : 'text-neutral-300'}`}
+                >
+                  {unknownName ? '정보 없음' : name || '---'}
+                </p>
+              </div>
+              <div>
+                <p className="text-detail-regular text-neutral-400">전화번호</p>
+                <p
+                  className={`text-body-3-bold transition-colors ${unknownPhone ? 'text-neutral-300 italic' : phone ? 'text-neutral-900' : 'text-neutral-300'}`}
+                >
+                  {unknownPhone ? '정보 없음' : phone || '---'}
+                </p>
+              </div>
+              <div>
+                <p className="text-detail-regular text-neutral-400">이메일</p>
+                <p
+                  className={`text-body-3-bold transition-colors ${unknownEmail ? 'text-neutral-300 italic' : email ? 'text-neutral-900' : 'text-neutral-300'}`}
+                >
+                  {unknownEmail ? '정보 없음' : email || '---'}
+                </p>
+              </div>
+              <div>
+                <p className="text-detail-regular text-neutral-400">주소</p>
+                <p
+                  className={`text-body-3-bold transition-colors ${unknownAddr ? 'text-neutral-300 italic' : hasAddress ? 'text-neutral-900' : 'text-neutral-300'}`}
+                >
+                  {unknownAddr
+                    ? '정보 없음'
+                    : hasAddress
+                      ? [addr1, addr2, addr3].filter(Boolean).join(' ')
+                      : '---'}
+                </p>
+              </div>
+            </div>
+            {/* Bottom row: extra */}
+            <div className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-neutral-200 px-5 py-4">
+              <div>
+                <p className="text-detail-regular text-neutral-400">직업</p>
+                <p
+                  className={`text-body-3-bold transition-colors ${unknownOccupation ? 'text-neutral-300 italic' : occupation ? 'text-neutral-900' : 'text-neutral-300'}`}
+                >
+                  {unknownOccupation ? '정보 없음' : occupation || '---'}
+                </p>
+              </div>
+              <div>
+                <p className="text-detail-regular text-neutral-400">사무실 주소</p>
+                <p
+                  className={`text-body-3-bold transition-colors ${unknownOfficeAddress ? 'text-neutral-300 italic' : hasOfficeAddress ? 'text-neutral-900' : 'text-neutral-300'}`}
+                >
+                  {unknownOfficeAddress
+                    ? '정보 없음'
+                    : hasOfficeAddress
+                      ? [officeAddr1, officeAddr2, officeAddr3].filter(Boolean).join(' ')
+                      : '---'}
+                </p>
+              </div>
+              <div>
+                <p className="text-detail-regular text-transparent">-</p>
+                <p className="text-body-3-bold text-transparent">-</p>
+              </div>
+              <div>
+                <p className="text-detail-regular text-transparent">-</p>
+                <p className="text-body-3-bold text-transparent">-</p>
+              </div>
+            </div>
+          </div>
+        </div>
 
+        {/* 입력 폼 카드 */}
+        <div className="w-full max-w-[520px]">
+          <div className="max-h-[480px] overflow-y-auto rounded-2xl border border-neutral-200 bg-white shadow-sm">
+            {/* 기본 정보 서브헤더 */}
+            <div className="flex items-center justify-between border-b border-neutral-100 bg-neutral-50 px-5 py-3">
+              <span className="text-detail-bold text-neutral-500">기본 정보</span>
+              <label className="text-detail-regular inline-flex cursor-pointer items-center gap-1.5 text-neutral-500">
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5 cursor-pointer"
+                  checked={allBasicUnknown}
+                  onChange={(e) => handleToggleAllBasic(e.target.checked)}
+                />
+                전체 정보 없음
+              </label>
+            </div>
+
+            {/* 이름 */}
+            <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+              <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">이름</span>
               <input
                 disabled={unknownName}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className={[
-                  'rounded-200 h-10 flex-1 px-3',
-                  'border border-neutral-300',
-                  'disabled:bg-neutral-100 disabled:text-neutral-400',
-                  'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                ].join(' ')}
-                placeholder={unknownName ? '모름' : '이름 입력'}
+                className="rounded-200 text-body-3-regular focus:border-primary-400 focus:ring-primary-400 h-9 flex-1 border border-neutral-300 px-3 outline-none focus:ring-2 disabled:bg-neutral-100 disabled:text-neutral-400"
+                placeholder={unknownName ? '정보 없음' : '이름 입력'}
                 type="text"
               />
-
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
+              <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
+                  className="h-3.5 w-3.5 cursor-pointer"
                   checked={unknownName}
                   onChange={(e) => handleCheckboxChange(e.target.checked, setUnknownName, setName)}
                 />
-                모름
+                정보 없음
               </label>
             </div>
-          </div>
 
-          {/* 이메일 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('이메일', true)}
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                email
-              </span>
-
+            {/* 이메일 */}
+            <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+              <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">이메일</span>
               <input
                 disabled={unknownEmail}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className={[
-                  'rounded-200 h-10 flex-1 px-3',
-                  'border border-neutral-300',
-                  'disabled:bg-neutral-100 disabled:text-neutral-400',
-                  'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                ].join(' ')}
-                placeholder={unknownEmail ? '모름' : '이메일 입력'}
+                className="rounded-200 text-body-3-regular focus:border-primary-400 focus:ring-primary-400 h-9 flex-1 border border-neutral-300 px-3 outline-none focus:ring-2 disabled:bg-neutral-100 disabled:text-neutral-400"
+                placeholder={unknownEmail ? '정보 없음' : '이메일 입력'}
                 type="text"
               />
-
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
+              <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
+                  className="h-3.5 w-3.5 cursor-pointer"
                   checked={unknownEmail}
                   onChange={(e) =>
                     handleCheckboxChange(e.target.checked, setUnknownEmail, setEmail)
                   }
                 />
-                모름
+                정보 없음
               </label>
             </div>
-          </div>
 
-          {/* 주소 */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              {/* 주소 라벨 */}
-              {renderLabel('주소', true)}
-
-              {/* 주소 검색 버튼 */}
-              <DaumPostcodeButton onSelect={handleAddressSelect} />
-            </div>
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                location_on
-              </span>
-
-              <div className="grid w-full grid-cols-3 gap-2">
-                <input
-                  disabled={unknownAddr}
-                  value={addr1}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownAddr ? '모름' : '시/도'}
-                  type="text"
-                />
-                <input
-                  disabled={unknownAddr}
-                  value={addr2}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownAddr ? '모름' : '시/군/구'}
-                  type="text"
-                />
-                <input
-                  disabled={unknownAddr}
-                  value={addr3}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownAddr ? '모름' : '읍/면/동'}
-                  type="text"
-                />
-              </div>
-
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
+            {/* 전화번호 */}
+            <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+              <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">전화번호</span>
+              <input
+                type="tel"
+                inputMode="numeric"
+                placeholder={unknownPhone ? '정보 없음' : '010-1234-5678'}
+                value={phone}
+                onChange={handlePhoneChange}
+                disabled={unknownPhone}
+                className="rounded-200 text-body-3-regular focus:border-primary-400 focus:ring-primary-400 h-9 flex-1 border border-neutral-300 px-3 outline-none focus:ring-2 disabled:bg-neutral-100 disabled:text-neutral-400"
+                autoComplete="tel"
+              />
+              <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
+                  className="h-3.5 w-3.5 cursor-pointer"
+                  checked={unknownPhone}
+                  onChange={(e) => {
+                    if (e.target.checked) setPhone('');
+                    setUnknownPhone(e.target.checked);
+                  }}
+                />
+                정보 없음
+              </label>
+            </div>
+
+            {/* 주소 */}
+            <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+              <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">주소</span>
+              <div className="flex-1">
+                {unknownAddr ? (
+                  <div className="rounded-200 flex h-9 w-full items-center border border-neutral-300 bg-neutral-100 px-3 text-neutral-400">
+                    정보 없음
+                  </div>
+                ) : (
+                  <DaumPostcodeButton
+                    onSelect={handleAddressSelect}
+                    address={hasAddress ? { city: addr1, district: addr2, town: addr3 } : undefined}
+                  />
+                )}
+              </div>
+              <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5 cursor-pointer"
                   checked={unknownAddr}
                   onChange={(e) => {
-                    const checked = e.target.checked;
-
-                    handleCheckboxChange(checked, setUnknownAddr, setAddr1, setAddr2, setAddr3);
-
-                    if (checked) {
-                      // "주소 모름"으로 바꾸면 주소 관련 에러는 지워준다
+                    handleCheckboxChange(
+                      e.target.checked,
+                      setUnknownAddr,
+                      setAddr1,
+                      setAddr2,
+                      setAddr3,
+                    );
+                    if (e.target.checked) {
                       setErr(null);
-                      setHasAddress(false); // 선택사항: 모름이면 hasAddress도 false로
+                      setHasAddress(false);
                     }
                   }}
                 />
-                모름
+                정보 없음
               </label>
             </div>
-          </div>
 
-          {/* 연락처 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('전화번호', true)}
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                phone_in_talk
-              </span>
-
-              <div className="grid w-full grid-cols-3 gap-2">
-                <input
-                  disabled={unknownPhone}
-                  value={p1}
-                  onChange={(e) => setP1(e.target.value.replace(/\D/g, '').slice(0, 3))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownPhone ? '모름' : '010'}
-                  inputMode="numeric"
-                />
-                <input
-                  disabled={unknownPhone}
-                  value={p2}
-                  onChange={(e) => setP2(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownPhone ? '모름' : '1234'}
-                  inputMode="numeric"
-                />
-                <input
-                  disabled={unknownPhone}
-                  value={p3}
-                  onChange={(e) => setP3(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownPhone ? '모름' : '5678'}
-                  inputMode="numeric"
-                />
-              </div>
-
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
+            {/* 추가 정보 서브헤더 */}
+            <div className="flex items-center justify-between border-b border-neutral-100 bg-neutral-50 px-5 py-3">
+              <span className="text-detail-bold text-neutral-500">추가 정보</span>
+              <label className="text-detail-regular inline-flex cursor-pointer items-center gap-1.5 text-neutral-500">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
-                  checked={unknownPhone}
+                  className="h-3.5 w-3.5 cursor-pointer"
+                  checked={allExtraUnknown}
+                  onChange={(e) => handleToggleAllExtra(e.target.checked)}
+                />
+                전체 정보 없음
+              </label>
+            </div>
+
+            {/* 직업 */}
+            <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+              <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">직업</span>
+              <input
+                disabled={unknownOccupation}
+                value={occupation}
+                onChange={(e) => setOccupation(e.target.value)}
+                className="rounded-200 text-body-3-regular focus:border-primary-400 focus:ring-primary-400 h-9 flex-1 border border-neutral-300 px-3 outline-none focus:ring-2 disabled:bg-neutral-100 disabled:text-neutral-400"
+                placeholder={unknownOccupation ? '정보 없음' : '예: 회사원, 자영업자 등'}
+                type="text"
+              />
+              <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5 cursor-pointer"
+                  checked={unknownOccupation}
                   onChange={(e) =>
-                    handleCheckboxChange(e.target.checked, setUnknownPhone, setP1, setP2, setP3)
+                    handleCheckboxChange(e.target.checked, setUnknownOccupation, setOccupation)
                   }
                 />
-                모름
+                정보 없음
               </label>
+            </div>
+
+            {/* 사무실 주소 */}
+            <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+              <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">사무실 주소</span>
+              <div className="flex-1">
+                {unknownOfficeAddress ? (
+                  <div className="rounded-200 flex h-9 w-full items-center border border-neutral-300 bg-neutral-100 px-3 text-neutral-400">
+                    정보 없음
+                  </div>
+                ) : (
+                  <DaumPostcodeButton
+                    onSelect={handleOfficeAddressSelect}
+                    address={
+                      hasOfficeAddress
+                        ? { city: officeAddr1, district: officeAddr2, town: officeAddr3 }
+                        : undefined
+                    }
+                  />
+                )}
+              </div>
+              <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5 cursor-pointer"
+                  checked={unknownOfficeAddress}
+                  onChange={(e) => {
+                    handleCheckboxChange(
+                      e.target.checked,
+                      setUnknownOfficeAddress,
+                      setOfficeAddr1,
+                      setOfficeAddr2,
+                      setOfficeAddr3,
+                    );
+                    if (e.target.checked) {
+                      setErr(null);
+                      setHasOfficeAddress(false);
+                    }
+                  }}
+                />
+                정보 없음
+              </label>
+            </div>
+
+            {/* 기타 정보 */}
+            <div className="flex items-start gap-4 px-5 py-3">
+              <span className="text-body-3-bold w-20 shrink-0 pt-2 text-neutral-600">
+                기타 정보
+              </span>
+              <textarea
+                value={etc}
+                onChange={(e) => setEtc(e.target.value)}
+                className="rounded-200 text-body-3-regular focus:border-primary-400 focus:ring-primary-400 min-h-[100px] flex-1 resize-y border border-neutral-300 px-3 py-2 outline-none focus:ring-2"
+                placeholder="계좌 번호, 관계 등 특정할 수 있는 정보"
+              />
             </div>
           </div>
         </div>

--- a/src/features/complaint/sections/ChatInfoSection.tsx
+++ b/src/features/complaint/sections/ChatInfoSection.tsx
@@ -1,34 +1,60 @@
 import React from 'react';
 
-import BaroCharacter from '@/assets/BaLawCharacter-large.svg';
-
-import IntroHeader from '@/shared/ui/IntroHeader';
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
 
 const ChatInfoSection: React.FC = () => {
   return (
     <section
-      className={[
-        'flex flex-col items-center justify-between',
-        'h-[600px] w-full max-w-[1000px]',
-        'pb-6',
-        'bg-neutral-0',
-      ].join(' ')}
+      className={['flex flex-col items-center', 'w-full flex-1', 'pb-6', 'bg-neutral-0'].join(' ')}
     >
-      <IntroHeader
-        title="고소장 작성하기"
-        lines={[
-          '기본 정보들은 확실히 작성 하셨나요?',
-          '바로와 채팅을 시작하면 이전으로 돌아갈 수 없어요.',
-          '나와 상대방의 정보를 확실하게 작성했다면, 다음으로 넘어가주세요.',
-        ]}
-        center
-        showArrow
-      />
-      <div className="flex flex-1 flex-col items-center justify-center">
+      <div className="flex flex-1 flex-col items-center justify-center gap-4">
+        {/* 말풍선 - 캐릭터 위에 표시 */}
+        <div className="animate-bubble-up relative max-w-[520px]">
+          {/* 말풍선 본체 */}
+          <div className="rounded-300 border-primary-100 bg-primary-0/40 border px-6 py-4 md:px-8 md:py-5">
+            <div className="flex flex-col gap-1 text-center">
+              <p className="text-body-2-bold md:text-body-1-bold text-neutral-800">
+                준비가 다 됐나요?
+              </p>
+              <p className="text-body-3-regular md:text-body-2-regular text-neutral-500">
+                바로와 채팅을 시작하면 이전으로 돌아갈 수 없어요.
+                <br />
+                나와 상대방의 정보를 확실하게 작성했다면,
+                <br />
+                다음으로 넘어가주세요.
+              </p>
+            </div>
+          </div>
+          {/* 말풍선 꼬리 (아래쪽) */}
+          <svg
+            className="mx-auto block"
+            width="16"
+            height="8"
+            viewBox="0 0 16 8"
+            fill="none"
+          >
+            <path
+              d="M0 0 L8 8 L16 0"
+              className="fill-primary-0/40 stroke-primary-100"
+              strokeWidth="1"
+            />
+            <line
+              x1="0"
+              y1="0"
+              x2="16"
+              y2="0"
+              className="stroke-primary-0/40"
+              strokeWidth="2"
+            />
+          </svg>
+        </div>
+
+        {/* 바로 캐릭터 - 뿅 등장 */}
         <img
-          src={BaroCharacter}
+          src={characterUrl}
           alt="바로 캐릭터"
-          className="h-64 w-64 object-contain"
+          className="animate-pop-in h-40 w-40 md:h-52 md:w-52 lg:h-60 lg:w-60"
+          draggable={false}
         />
       </div>
     </section>

--- a/src/features/complaint/sections/ChatWindowSection.tsx
+++ b/src/features/complaint/sections/ChatWindowSection.tsx
@@ -2,8 +2,6 @@ import type { AxiosError } from 'axios';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-import Button from '@/shared/ui/common/Button';
-
 import type { ChatMetaPayload, RagCase } from '@/features/complaint/apis/complaints';
 import {
   type ChatMessageHistoryItem,
@@ -70,6 +68,14 @@ const ChatWindowSection: React.FC<Props> = ({
   initialAiSessionId = null,
 }) => {
   const listRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const resizeTextarea = () => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = '24px';
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  };
 
   const [aiSessionId, setAiSessionId] = useState<string | null>(
     mode === 'resume' ? initialAiSessionId : null,
@@ -92,7 +98,7 @@ const ChatWindowSection: React.FC<Props> = ({
       {
         id: `intro-${Date.now()}`,
         side: 'left',
-        text: '먼저 사건의 경위를 자유롭게 작성해 주세요.',
+        text: '안녕하세요, 바로예요 👋\n\n어떤 일이 있었는지 알려주세요.\n언제, 어디서, 누구에게, 어떤 피해를 입었는지 자세히 적어주시면 고소장 작성에 큰 도움이 돼요.',
         time: fmtTime(),
       },
     ]);
@@ -108,21 +114,41 @@ const ChatWindowSection: React.FC<Props> = ({
         const history: ChatMessageHistoryItem[] = await getChatHistory(complaintId);
 
         if (!history || history.length === 0) {
-          setMsgs([
-            {
-              id: `resume-${Date.now()}`,
-              side: 'left',
-              text: '사건 개요를 입력해주세요.',
-              time: fmtTime(),
-            },
-          ]);
+          // 히스토리도 없고 ai_session_id도 없으면 처음부터 시작
+          if (!initialAiSessionId) {
+            setPhase('askSummary');
+            setMsgs([
+              {
+                id: `intro-${Date.now()}`,
+                side: 'left',
+                text: '안녕하세요, 바로예요 👋\n\n어떤 일이 있었는지 알려주세요.\n언제, 어디서, 누구에게, 어떤 피해를 입었는지 자세히 적어주시면 고소장 작성에 큰 도움이 돼요.',
+                time: fmtTime(),
+              },
+            ]);
+          } else {
+            setMsgs([
+              {
+                id: `resume-${Date.now()}`,
+                side: 'left',
+                text: '사건 개요를 입력해주세요.',
+                time: fmtTime(),
+              },
+            ]);
+          }
         } else {
           const restored: Msg[] = [];
           let lastMeta: ChatMetaPayload | undefined;
 
+          const AUTO_MSG = '위 사건 개요를 기반으로, 이어서 질문을 해 주세요.';
+
           history.forEach((msg, idx) => {
             if (isAiMetaMessage(msg.content)) {
-              lastMeta = msg.content; // 여기서 content가 ChatMetaPayload로 좁혀짐
+              lastMeta = msg.content;
+              return;
+            }
+
+            // 자동 발송 메시지는 히스토리에서 숨김
+            if (typeof msg.content === 'string' && msg.content === AUTO_MSG) {
               return;
             }
 
@@ -147,6 +173,14 @@ const ChatWindowSection: React.FC<Props> = ({
               time: fmtTime(),
             });
           }
+
+          // 맨 위에 안내 메시지 삽입
+          restored.unshift({
+            id: `intro-${Date.now()}`,
+            side: 'left',
+            text: '안녕하세요, 바로예요 👋\n\n어떤 일이 있었는지 알려주세요.\n언제, 어디서, 누구에게, 어떤 피해를 입었는지 자세히 적어주시면 고소장 작성에 큰 도움이 돼요.',
+            time: restored.length > 0 ? restored[0].time : fmtTime(),
+          });
 
           setMsgs(restored);
 
@@ -239,6 +273,7 @@ const ChatWindowSection: React.FC<Props> = ({
 
       setMsgs((prev) => [...prev, userMsg]);
       setInput('');
+      if (textareaRef.current) textareaRef.current.style.height = '24px';
 
       setPhase('initializing');
       setIsBotTyping(true);
@@ -297,16 +332,6 @@ const ChatWindowSection: React.FC<Props> = ({
         setMsgs((prev) => {
           const nextMsgs = [...prev, keywordMsg, ...(firstQuestionMsg ? [firstQuestionMsg] : [])];
 
-          if (isDoneReply) {
-            const guideMsg: Msg = {
-              id: `done-guide-${Date.now()}`,
-              side: 'left',
-              text: '화면 오른쪽 아래의 "다음" 버튼을 눌러, AI가 작성한 고소장 초안을 확인해 주세요.',
-              time: fmtTime(),
-            };
-            nextMsgs.push(guideMsg);
-          }
-
           return nextMsgs;
         });
 
@@ -361,6 +386,7 @@ const ChatWindowSection: React.FC<Props> = ({
     };
     setMsgs((prev) => [...prev, userMsg]);
     setInput('');
+    if (textareaRef.current) textareaRef.current.style.height = '24px';
 
     try {
       setIsBotTyping(true);
@@ -376,21 +402,7 @@ const ChatWindowSection: React.FC<Props> = ({
 
       const isDoneReply = reply.includes(DONE_PHRASE);
 
-      setMsgs((prev) => {
-        const nextMsgs = [...prev, botMsg];
-
-        if (isDoneReply) {
-          const guideMsg: Msg = {
-            id: `done-guide-${Date.now()}`,
-            side: 'left',
-            text: '화면 오른쪽 아래의 "다음" 버튼을 눌러, AI가 작성한 고소장 초안을 미리보기로 확인해 주세요.',
-            time: fmtTime(),
-          };
-          nextMsgs.push(guideMsg);
-        }
-
-        return nextMsgs;
-      });
+      setMsgs((prev) => [...prev, botMsg]);
 
       if (isDoneReply) {
         setIsCompleted(true);
@@ -429,90 +441,124 @@ const ChatWindowSection: React.FC<Props> = ({
     }
   };
 
-  const inputDisabled = phase === 'initializing' || isCompleted;
+  const inputDisabled = phase === 'initializing' || isCompleted || isBotTyping;
 
   return (
     <section
       className={[
-        'flex min-h-0 flex-1 flex-col items-center justify-between',
-        'h-[600px] w-full xl:h-[680px]',
-        'pt-2 pb-6',
-        'bg-neutral-0',
+        'flex flex-col',
+        'min-h-0 w-full flex-1 overflow-hidden',
+        'rounded-2xl border border-neutral-200 bg-neutral-50 shadow-sm',
       ].join(' ')}
     >
-      <div className="flex min-h-0 w-full flex-1 justify-center">
-        <div
-          className={[
-            'flex min-h-0 w-full max-w-[720px] flex-1 flex-col',
-            'rounded-200 bg-neutral-0 border border-gray-300',
-            'px-6 py-3',
-          ].join(' ')}
-        >
-          {/* 🔹 실제로 스크롤 되는 영역 (padding / border 없음) */}
-          <div
-            ref={listRef}
-            className="balaw-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto px-2"
-            role="list"
-            aria-label="채팅 메시지"
+      {/* 채팅 헤더 */}
+      <div className="flex items-center gap-3 border-b border-neutral-200 bg-white px-6 py-3">
+        <div className="bg-primary-400 flex h-8 w-8 items-center justify-center rounded-full">
+          <span
+            className="material-symbols-outlined text-white"
+            style={{ fontSize: '18px' }}
           >
-            {msgs.map((m) => (
-              <ChatBubble
-                key={m.id}
-                side={m.side}
-                text={m.text}
-                time={m.time}
-                srLabel={`${m.side === 'left' ? '바로' : '사용자'} 메시지`}
-              />
-            ))}
-            {isBotTyping && (
-              <ChatBubble
-                side="left"
-                text="..."
-                time={fmtTime()}
-                srLabel="바로가 입력 중입니다."
-                isTyping
-              />
-            )}
-          </div>
+            smart_toy
+          </span>
+        </div>
+        <div>
+          <p className="text-body-3-bold text-neutral-800">바로 AI</p>
+          <p className="text-detail-regular text-neutral-400">
+            {isBotTyping ? '입력 중...' : '고소장 작성 도우미'}
+          </p>
         </div>
       </div>
 
+      {/* 메시지 영역 */}
       <div
-        className={[
-          'mt-2 flex w-full max-w-[720px] items-center justify-between',
-          'rounded-200 bg-neutral-0 border border-blue-400',
-          'px-5 py-2.5',
-        ].join(' ')}
-        aria-label="채팅 입력 영역"
+        ref={listRef}
+        className="balaw-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4 md:px-6"
+        role="list"
+        aria-label="채팅 메시지"
       >
-        <textarea
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder={
-            mode === 'new' && phase === 'askSummary'
-              ? '사건의 경위를 자유롭게 입력해 주세요.'
-              : '여기에 입력하고 Enter로 전송하세요. (줄바꿈은 Shift+Enter)'
-          }
-          rows={2}
-          aria-label="메시지 입력"
-          disabled={inputDisabled}
+        {msgs.map((m) => (
+          <ChatBubble
+            key={m.id}
+            side={m.side}
+            text={m.text}
+            time={m.time}
+            srLabel={`${m.side === 'left' ? '바로' : '사용자'} 메시지`}
+          />
+        ))}
+        {isBotTyping && (
+          <ChatBubble
+            side="left"
+            text="..."
+            time={fmtTime()}
+            srLabel="바로가 입력 중입니다."
+            isTyping
+          />
+        )}
+      </div>
+
+      {/* 입력 영역 */}
+      <div className="border-t border-neutral-200 bg-white px-4 py-3 md:px-6">
+        <div
           className={[
-            'flex-1 resize-none text-left',
-            'text-body-3-regular leading-5',
-            'text-neutral-700 placeholder:text-neutral-500',
-            'focus:outline-none disabled:opacity-50',
+            'flex items-end gap-2',
+            input.length > 60 || input.includes(' ') ? 'rounded-2xl' : 'rounded-full',
+            'border border-neutral-300 bg-neutral-50',
+            'px-4 py-2',
+            'focus-within:border-primary-400 focus-within:ring-primary-400/20 focus-within:ring-2',
+            'transition-all',
           ].join(' ')}
-        />
-        <Button
-          variant="primary"
-          size="sm"
-          className="w-16"
-          onClick={handleSend}
-          disabled={inputDisabled || !input.trim()}
         >
-          전송
-        </Button>
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              resizeTextarea();
+            }}
+            onInput={resizeTextarea}
+            onKeyDown={onKeyDown}
+            placeholder={
+              isBotTyping
+                ? '바로가 입력 중이에요...'
+                : mode === 'new' && phase === 'askSummary'
+                  ? '사건의 경위를 자유롭게 입력해 주세요...'
+                  : '메시지를 입력해주세요...'
+            }
+            rows={1}
+            aria-label="메시지 입력"
+            disabled={inputDisabled}
+            className={[
+              'flex-1 resize-none bg-transparent',
+              'text-body-3-regular leading-relaxed',
+              'text-neutral-800 placeholder:text-neutral-400',
+              'focus:outline-none disabled:opacity-50',
+              'h-[24px] max-h-[120px] overflow-y-auto',
+            ].join(' ')}
+          />
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={inputDisabled || !input.trim()}
+            className={[
+              'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+              'transition-all duration-200',
+              inputDisabled || !input.trim()
+                ? 'bg-neutral-200 text-neutral-400'
+                : 'bg-primary-400 hover:bg-primary-500 text-white active:scale-95',
+            ].join(' ')}
+            aria-label="전송"
+          >
+            <span
+              className="material-symbols-outlined"
+              style={{ fontSize: '18px' }}
+            >
+              arrow_upward
+            </span>
+          </button>
+        </div>
+        <p className="text-detail-regular mt-1.5 text-center text-neutral-400">
+          Enter로 전송 · Shift+Enter로 줄바꿈
+        </p>
       </div>
     </section>
   );

--- a/src/features/complaint/sections/ComplaintDownloadSection.tsx
+++ b/src/features/complaint/sections/ComplaintDownloadSection.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 
-import DocxIcon from '@/assets/Docs.svg';
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
 
-import IntroHeader from '@/shared/ui/IntroHeader';
 import Button from '@/shared/ui/common/Button';
 
 import { downloadComplaintDocx } from '@/features/complaint/apis/complaints';
@@ -13,12 +12,13 @@ type ComplaintDownloadSectionProps = {
 
 const ComplaintDownloadSection: React.FC<ComplaintDownloadSectionProps> = ({ complaintId }) => {
   const [isDownloading, setIsDownloading] = useState(false);
+  const [downloaded, setDownloaded] = useState(false);
 
   const handleDownload = async () => {
     try {
       setIsDownloading(true);
       await downloadComplaintDocx(complaintId);
-      // 필요하면 토스트 등으로 "다운로드가 시작됐어요" 안내
+      setDownloaded(true);
     } catch (e) {
       console.error('failed to download docx', e);
       alert('DOCX 파일 다운로드에 실패했어요. 잠시 후 다시 시도해 주세요.');
@@ -30,82 +30,104 @@ const ComplaintDownloadSection: React.FC<ComplaintDownloadSectionProps> = ({ com
   return (
     <section
       aria-label={`고소장 DOCX 다운로드 (ID: ${complaintId})`}
-      className={[
-        'mx-auto flex flex-col items-center',
-        'h-[600px] w-full max-w-[1000px]',
-        'bg-neutral-0 pt-6 pb-6',
-      ].join(' ')}
+      className="mx-auto flex w-full max-w-[520px] flex-1 flex-col items-center justify-center gap-6"
     >
-      <IntroHeader
-        title="고소장 DOCX 파일로 저장하기"
-        lines={[
-          'AI가 작성한 고소장을 Word(DOCX) 파일로 내려받을 수 있어요.',
-          '다운로드 후에 내용을 직접 수정하거나 인쇄해서 사용할 수 있습니다.',
-        ]}
-        center
-        showArrow
-      />
+      {/* 캐릭터 + 말풍선 */}
+      <div className="flex flex-col items-center gap-3">
+        <img
+          src={characterUrl}
+          alt="바로 캐릭터"
+          className="animate-pop-in h-28 w-28 md:h-36 md:w-36"
+          draggable={false}
+        />
+        <div className="animate-bubble-up border-primary-100 bg-primary-0/40 rounded-2xl border px-6 py-4 text-center">
+          <p className="text-body-2-bold md:text-body-1-bold text-neutral-800">
+            {downloaded ? '다운로드가 완료됐어요!' : '고소장이 완성됐어요!'}
+          </p>
+          <p className="text-body-3-regular md:text-body-2-regular mt-1 text-neutral-500">
+            {downloaded
+              ? '파일을 열어서 내용을 확인해보세요.'
+              : 'Word 파일로 다운로드해서 확인하고 제출해보세요.'}
+          </p>
+        </div>
+      </div>
 
-      <div
-        className={[
-          'mt-8 flex min-h-0 w-full max-w-[520px] flex-1 flex-col',
-          'rounded-200 bg-neutral-0 border border-neutral-200 shadow-sm',
-          'px-6 py-5',
-        ].join(' ')}
-      >
-        {/* 상단 아이콘 + 타이틀 */}
-        <div className="mb-6 flex items-center gap-3">
-          <div
-            className={[
-              'flex h-10 w-10 items-center justify-center',
-              'bg-primary-50 text-primary-500 rounded-full',
-              'text-body-2-bold',
-            ].join(' ')}
-          >
-            W
-          </div>
-          <div className="flex flex-col">
-            <span className="text-caption-regular text-neutral-500">문서 ID #{complaintId}</span>
-            <span className="text-body-2-bold text-neutral-900">
-              고소장을 Word 문서로 저장할 수 있어요
+      {/* 다운로드 카드 */}
+      <div className="w-full rounded-2xl border border-neutral-200 bg-white shadow-sm">
+        {/* 파일 정보 */}
+        <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-4">
+          <div className="bg-primary-100 flex h-12 w-12 items-center justify-center rounded-xl">
+            <span
+              className="material-symbols-outlined text-primary-500"
+              style={{ fontSize: '28px' }}
+            >
+              description
             </span>
           </div>
+          <div className="flex flex-col">
+            <span className="text-body-3-bold text-neutral-800">고소장_{complaintId}.docx</span>
+            <span className="text-detail-regular text-neutral-400">Word 문서 파일</span>
+          </div>
         </div>
 
-        {/* 안내 텍스트/단계 */}
-        <div className="text-body-3-regular mb-5 space-y-2 text-neutral-700">
-          <p>아래 버튼을 눌러 DOCX 파일을 내려받은 뒤, 필요에 따라 수정·보관해 주세요.</p>
-          <ul className="text-caption-regular space-y-1 text-neutral-600">
-            <li>1️⃣ 다운로드한 파일을 열어 내용이 정확한지 다시 한 번 확인해 주세요.</li>
-            <li>2️⃣ 필요하다면 일부 문장을 직접 수정하거나 추가 메모를 남길 수 있어요.</li>
-            <li>3️⃣ 완성된 문서를 인쇄해 제출하거나, 전자문서로 보관할 수 있습니다.</li>
-          </ul>
+        {/* 안내 사항 */}
+        <div className="space-y-2 border-b border-neutral-100 px-5 py-4">
+          <div className="flex items-start gap-2">
+            <span
+              className="material-symbols-outlined text-primary-300 mt-0.5"
+              style={{ fontSize: '16px' }}
+            >
+              check_circle
+            </span>
+            <p className="text-detail-regular text-neutral-600">
+              다운로드한 파일을 열어 내용이 정확한지 확인해주세요
+            </p>
+          </div>
+          <div className="flex items-start gap-2">
+            <span
+              className="material-symbols-outlined text-primary-300 mt-0.5"
+              style={{ fontSize: '16px' }}
+            >
+              check_circle
+            </span>
+            <p className="text-detail-regular text-neutral-600">
+              필요하다면 문장을 수정하거나 메모를 추가할 수 있어요
+            </p>
+          </div>
+          <div className="flex items-start gap-2">
+            <span
+              className="material-symbols-outlined text-primary-300 mt-0.5"
+              style={{ fontSize: '16px' }}
+            >
+              check_circle
+            </span>
+            <p className="text-detail-regular text-neutral-600">
+              완성된 문서를 인쇄해 제출하거나 전자문서로 보관하세요
+            </p>
+          </div>
         </div>
 
-        {/* 버튼 영역 */}
-        <div className="mt-auto flex flex-col items-center gap-3">
+        {/* 다운로드 버튼 */}
+        <div className="px-5 py-4">
           <Button
-            variant="primary"
-            size="md"
+            variant={downloaded ? 'secondary' : 'primary'}
+            size="lg"
             fullWidth
             onClick={handleDownload}
             disabled={isDownloading}
           >
-            {/* DOCX 아이콘 */}
-            <span className="bg-primary-400/15 flex h-9 w-9 items-center justify-center rounded-[12px]">
-              <img
-                src={DocxIcon}
-                alt="DOCX 파일 아이콘"
-                className="h-5 w-5"
-              />
+            <span
+              className="material-symbols-outlined mr-2"
+              style={{ fontSize: '20px' }}
+            >
+              {downloaded ? 'refresh' : 'download'}
             </span>
-
-            {isDownloading ? '다운로드 준비 중...' : 'DOCX 파일 다운로드'}
+            {isDownloading
+              ? '다운로드 준비 중...'
+              : downloaded
+                ? '다시 다운로드'
+                : 'DOCX 파일 다운로드'}
           </Button>
-
-          <p className="text-detail-regular text-neutral-500">
-            * 브라우저의 팝업 차단 설정에 따라 다운로드 창이 보이지 않을 수 있어요.
-          </p>
         </div>
       </div>
     </section>

--- a/src/features/complaint/sections/ComplaintEntrySection.tsx
+++ b/src/features/complaint/sections/ComplaintEntrySection.tsx
@@ -21,12 +21,7 @@ const ComplaintEntrySection: React.FC<ComplaintEntrySectionProps> = ({
 
   return (
     <section
-      className={[
-        'flex flex-col items-center justify-between',
-        'h-[600px] w-full max-w-[1000px]',
-        'pb-6',
-        'bg-neutral-0',
-      ].join(' ')}
+      className={['flex flex-col items-center', 'w-full flex-1', 'pb-6', 'bg-neutral-0'].join(' ')}
     >
       <IntroHeader
         title="고소장 작성하기"
@@ -38,97 +33,102 @@ const ComplaintEntrySection: React.FC<ComplaintEntrySectionProps> = ({
         showArrow
       />
 
-      {/* 카드 2개 가로/세로 반응형 배치 + 가운데 정렬 */}
-      <div className="flex w-full flex-1 flex-col items-center justify-center gap-6 px-4 md:flex-row">
-        {/* ─────────────────────
-            새 고소장 작성하기 카드
-        ───────────────────── */}
+      {/* 카드 2개 */}
+      <div className="mx-auto grid w-full max-w-[520px] flex-1 grid-cols-1 place-content-center justify-center gap-4 px-4 md:grid-cols-2 md:gap-6">
+        {/* 새 고소장 작성하기 */}
         <button
           type="button"
           onClick={onNew}
           className={[
-            'group flex flex-col items-center justify-center',
-            'h-[200px] w-[260px]',
-            'rounded-300 p-6',
-            // ghost base
-            'to-neutral-0/10 bg-radial from-neutral-200/40 via-neutral-100/10',
-            'border',
-            'shadow-[inset_0_1px_2px_rgba(255,255,255,0.12)]',
-            'backdrop-blur-md',
-            'transition-all duration-300 ease-out',
-            // active vs default
+            'group relative flex w-full flex-col items-center justify-center gap-4',
+            'rounded-300 px-6 py-10',
+            'border-2 bg-white',
+            'transition-all duration-200 ease-out',
             isNewActive
-              ? 'border-primary-300 ring-primary-200 ring-2'
-              : 'hover:ring-primary-50/40 border-white/50 hover:border-white/70 hover:ring-2',
+              ? 'border-primary-400 bg-primary-0/30 shadow-[0_0_0_3px_rgba(59,130,246,0.1)]'
+              : 'hover:border-primary-300 border-neutral-200 hover:shadow-md',
           ].join(' ')}
         >
-          {/* 아이콘 */}
-          <span
+          {/* 아이콘 배경 원 */}
+          <div
             className={[
-              'material-symbols-outlined',
-              'text-[60px]',
-              isNewActive ? 'text-primary-500' : 'text-neutral-600',
-              'group-hover:text-primary-400 transition-colors',
+              'flex h-14 w-14 items-center justify-center rounded-full transition-colors',
+              isNewActive ? 'bg-primary-400' : 'group-hover:bg-primary-100 bg-neutral-100',
             ].join(' ')}
           >
-            note_add
-          </span>
+            <span
+              className={[
+                'material-symbols-outlined transition-colors',
+                isNewActive ? 'text-white' : 'group-hover:text-primary-400 text-neutral-500',
+              ].join(' ')}
+              style={{ fontSize: '28px' }}
+            >
+              edit_note
+            </span>
+          </div>
 
-          {/* 제목 */}
-          <p
-            className={[
-              'text-body-2-bold mt-4',
-              isNewActive ? 'text-primary-500' : 'text-neutral-900',
-              'group-hover:text-primary-400 transition-colors',
-            ].join(' ')}
-          >
-            새 고소장 작성하기
-          </p>
+          {/* 텍스트 */}
+          <div className="flex flex-col items-center gap-1">
+            <p
+              className={[
+                'text-body-2-bold transition-colors',
+                isNewActive ? 'text-primary-500' : 'text-neutral-800',
+              ].join(' ')}
+            >
+              새 고소장 작성하기
+            </p>
+            <p className="text-detail-regular text-neutral-400">처음부터 새로 작성해요</p>
+          </div>
+
+          {/* 선택 체크 */}
         </button>
 
-        {/* ─────────────────────
-            이어 작성하기 카드
-        ───────────────────── */}
+        {/* 이어 작성하기 */}
         <button
           type="button"
           onClick={onResumeDrafts}
           className={[
-            'group flex flex-col items-center justify-center',
-            'h-[200px] w-[260px]',
-            'rounded-300 p-6',
-            // ghost base
-            'to-neutral-0/10 bg-radial from-neutral-200/40 via-neutral-100/10',
-            'border',
-            'shadow-[inset_0_1px_2px_rgba(255,255,255,0.12)]',
-            'backdrop-blur-md',
-            'transition-all duration-300 ease-out',
-            // active vs default
+            'group relative flex w-full flex-col items-center justify-center gap-4',
+            'rounded-300 px-6 py-10',
+            'border-2 bg-white',
+            'transition-all duration-200 ease-out',
             isResumeActive
-              ? 'border-primary-300 ring-primary-200 ring-2'
-              : 'hover:ring-primary-50/40 border-white/50 hover:border-white/70 hover:ring-2',
+              ? 'border-primary-400 bg-primary-0/30 shadow-[0_0_0_3px_rgba(59,130,246,0.1)]'
+              : 'hover:border-primary-300 border-neutral-200 hover:shadow-md',
           ].join(' ')}
         >
-          {/* 아이콘 */}
-          <span
+          <div
             className={[
-              'material-symbols-outlined',
-              'text-[60px]',
-              isResumeActive ? 'text-primary-500' : 'text-neutral-600',
-              'group-hover:text-primary-400 transition-colors',
+              'flex h-14 w-14 items-center justify-center rounded-full transition-colors',
+              isResumeActive ? 'bg-primary-400' : 'group-hover:bg-primary-100 bg-neutral-100',
             ].join(' ')}
           >
-            history
-          </span>
+            <span
+              className={[
+                'material-symbols-outlined transition-colors',
+                isResumeActive ? 'text-white' : 'group-hover:text-primary-400 text-neutral-500',
+              ].join(' ')}
+              style={{ fontSize: '28px' }}
+            >
+              draft
+            </span>
+          </div>
 
-          <p
-            className={[
-              'text-body-2-bold mt-4',
-              isResumeActive ? 'text-primary-500' : 'text-neutral-900',
-              'group-hover:text-primary-400 transition-colors',
-            ].join(' ')}
-          >
-            이어 작성하기
-          </p>
+          <div className="flex flex-col items-center gap-1">
+            <p
+              className={[
+                'text-body-2-bold transition-colors',
+                isResumeActive ? 'text-primary-500' : 'text-neutral-800',
+              ].join(' ')}
+            >
+              이어 작성하기
+            </p>
+            <p className="text-detail-regular text-neutral-400">
+              임시 저장한 고소장을
+              <br />
+              이어서 작성해요
+            </p>
+          </div>
         </button>
       </div>
     </section>

--- a/src/features/complaint/sections/ComplaintExtraInfoSection.tsx
+++ b/src/features/complaint/sections/ComplaintExtraInfoSection.tsx
@@ -4,7 +4,6 @@ import DaumPostcodeButton from '@/shared/ui/DaumPostcodeButton';
 import type { DaumPostcodeResult } from '@/shared/ui/DaumPostcodeButton';
 import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import IntroHeader from '@/shared/ui/IntroHeader';
-import { splitAddressTo3FromString } from '@/shared/utils/krContact';
 
 // 고소인 추가 정보 타입
 export type ComplainantExtraInfo = {
@@ -27,18 +26,11 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
 
   // 입력값 상태
   const [occupation, setOccupation] = useState('');
-
   const [officeAddr1, setOfficeAddr1] = useState('');
   const [officeAddr2, setOfficeAddr2] = useState('');
   const [officeAddr3, setOfficeAddr3] = useState('');
-
-  const [officeP1, setOfficeP1] = useState('');
-  const [officeP2, setOfficeP2] = useState('');
-  const [officeP3, setOfficeP3] = useState('');
-
-  const [homeP1, setHomeP1] = useState('');
-  const [homeP2, setHomeP2] = useState('');
-  const [homeP3, setHomeP3] = useState('');
+  const [officePhone, setOfficePhone] = useState('');
+  const [homePhone, setHomePhone] = useState('');
 
   // 비공개 토글
   const [unknownOccupation, setUnknownOccupation] = useState(false);
@@ -47,31 +39,28 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
   const [unknownHomePhone, setUnknownHomePhone] = useState(false);
 
   const [err, setErr] = useState<string | null>(null);
-
-  // 주소가 주소 찾기로 한 번이라도 세팅된 적 있는지
   const [hasAddress, setHasAddress] = useState(false);
 
-  // 주소 필드 클릭 시: 아직 검색 안했으면 에러만 보여주기
-  const handleAddressFieldClick = () => {
-    // "모름"이면 그냥 아무것도 하지 않음
-    if (unknownOfficeAddress) return;
-
-    // 주소가 비어 있고, 주소 찾기도 안 한 상태면 에러
-    if (!hasAddress && !officeAddr1 && !officeAddr2 && !officeAddr3) {
-      setErr('주소 찾기 버튼을 눌러 주소를 검색해주세요.');
-    }
-  };
-
-  // 주소 선택 콜백 (다음 API에서 선택되면 호출)
+  // 주소 선택 콜백
   const handleAddressSelect = (data: DaumPostcodeResult) => {
-    const { a1, a2, a3 } = splitAddressTo3FromString(data.roadAddress);
-    setOfficeAddr1(a1);
-    setOfficeAddr2(a2);
-    setOfficeAddr3(a3);
+    setOfficeAddr1(data.sido);
+    setOfficeAddr2(data.sigungu);
+    setOfficeAddr3(data.bname);
     setHasAddress(true);
     setUnknownOfficeAddress(false);
     setErr(null);
   };
+
+  // 전화번호 포맷팅
+  const formatPhone = (value: string) => {
+    const digits = value.replace(/\D/g, '').slice(0, 11);
+    if (digits.length <= 3) return digits;
+    if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  };
+
+  const officePhoneDigits = officePhone.replace(/\D/g, '');
+  const homePhoneDigits = homePhone.replace(/\D/g, '');
 
   const renderLabel = (text: string, required: boolean) => {
     const labelText = required ? '(필수)' : '(선택)';
@@ -96,17 +85,15 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
     return [officeAddr1, officeAddr2, officeAddr3].filter(Boolean).join(' ').trim();
   }, [officeAddr1, officeAddr2, officeAddr3, unknownOfficeAddress]);
 
-  const officePhone = useMemo(() => {
+  const officePhoneValue = useMemo(() => {
     if (unknownOfficePhone) return '';
-    if (!officeP1 && !officeP2 && !officeP3) return '';
-    return [officeP1, officeP2, officeP3].join('-').replace(/--+/g, '-');
-  }, [officeP1, officeP2, officeP3, unknownOfficePhone]);
+    return officePhoneDigits;
+  }, [officePhoneDigits, unknownOfficePhone]);
 
-  const homePhone = useMemo(() => {
+  const homePhoneValue = useMemo(() => {
     if (unknownHomePhone) return '';
-    if (!homeP1 && !homeP2 && !homeP3) return '';
-    return [homeP1, homeP2, homeP3].join('-').replace(/--+/g, '-');
-  }, [homeP1, homeP2, homeP3, unknownHomePhone]);
+    return homePhoneDigits;
+  }, [homePhoneDigits, unknownHomePhone]);
 
   const handleCheckboxChange = (
     checked: boolean,
@@ -117,7 +104,6 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
     if (checked) setters.forEach((setter) => setter(''));
   };
 
-  // 최종 객체 만들기 (유효성 검사는 안 하고 그대로 넘김)
   const buildExtraInfo = (): ComplainantExtraInfo => {
     if (!unknownOccupation && !occupation.trim()) {
       const msg = '직업을 입력하거나 "비공개"를 선택해주세요.';
@@ -129,12 +115,12 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
       setErr(msg);
       throw new Error(msg);
     }
-    if (!unknownOfficePhone && !officePhone) {
+    if (!unknownOfficePhone && officePhoneDigits.length < 9) {
       const msg = '사무실 전화번호를 입력하거나 "비공개"를 선택해주세요.';
       setErr(msg);
       throw new Error(msg);
     }
-    if (!unknownHomePhone && !homePhone) {
+    if (!unknownHomePhone && homePhoneDigits.length < 9) {
       const msg = '자택 전화번호를 입력하거나 "비공개"를 선택해주세요.';
       setErr(msg);
       throw new Error(msg);
@@ -145,8 +131,8 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
     return {
       occupation: unknownOccupation ? '비공개' : occupation.trim(),
       officeAddress: unknownOfficeAddress ? '비공개' : officeAddress.trim(),
-      officePhone: unknownOfficePhone ? '비공개' : officePhone,
-      homePhone: unknownHomePhone ? '비공개' : homePhone,
+      officePhone: unknownOfficePhone ? '비공개' : officePhoneValue,
+      homePhone: unknownHomePhone ? '비공개' : homePhoneValue,
       unknownOccupation,
       unknownOfficeAddress,
       unknownOfficePhone,
@@ -172,12 +158,7 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
 
   return (
     <section
-      className={[
-        'flex flex-col items-center justify-between',
-        'h-[600px] w-full max-w-[1000px]',
-        'pb-6',
-        'bg-neutral-0',
-      ].join(' ')}
+      className={['flex flex-col items-center', 'w-full flex-1', 'pb-6', 'bg-neutral-0'].join(' ')}
     >
       <IntroHeader
         title="고소장 작성하기"
@@ -192,296 +173,150 @@ const ComplainantExtraInfoSection = forwardRef<ComplainantExtraInfoSectionHandle
       <form
         ref={formRef}
         onSubmit={handleSubmit}
-        className="mt-6 flex w-[420px] flex-col gap-5"
+        className="mt-2 flex w-full flex-1 flex-col justify-center gap-5"
       >
-        <div className="flex flex-1 flex-col justify-center gap-6 px-5">
-          {/* 직업 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('직업', true)}
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                work
-              </span>
+        {/* 입력 필드 카드 */}
+        <div className="flex flex-1 items-center justify-center">
+          <div className="rounded-300 w-full max-w-[520px] border border-neutral-200 bg-white shadow-sm">
+            {/* 직업 */}
+            <div className="flex flex-col gap-2 border-b border-neutral-100 px-5 py-4">
+              <div className="flex items-center justify-between">
+                {renderLabel('직업', true)}
+                <label className="text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 cursor-pointer"
+                    checked={unknownOccupation}
+                    onChange={(e) =>
+                      handleCheckboxChange(e.target.checked, setUnknownOccupation, setOccupation)
+                    }
+                  />
+                  비공개
+                </label>
+              </div>
               <input
                 disabled={unknownOccupation}
                 value={occupation}
                 onChange={(e) => setOccupation(e.target.value)}
                 className={[
-                  'rounded-200 h-10 flex-1 px-3',
+                  'rounded-200 h-10 w-full px-3',
                   'border border-neutral-300',
                   'disabled:bg-neutral-100 disabled:text-neutral-400',
-                  'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
+                  'focus:border-primary-400 focus:ring-primary-400 outline-none focus:ring-2',
                 ].join(' ')}
                 placeholder={unknownOccupation ? '비공개' : '예: 회사원, 자영업자 등'}
                 type="text"
               />
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
-                  checked={unknownOccupation}
-                  onChange={(e) =>
-                    handleCheckboxChange(e.target.checked, setUnknownOccupation, setOccupation)
+            </div>
+
+            {/* 사무실 주소 */}
+            <div className="flex flex-col gap-2 border-b border-neutral-100 px-5 py-4">
+              <div className="flex items-center justify-between">
+                {renderLabel('사무실 주소', true)}
+                <label className="text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 cursor-pointer"
+                    checked={unknownOfficeAddress}
+                    onChange={(e) => {
+                      handleCheckboxChange(
+                        e.target.checked,
+                        setUnknownOfficeAddress,
+                        setOfficeAddr1,
+                        setOfficeAddr2,
+                        setOfficeAddr3,
+                      );
+                      if (e.target.checked) {
+                        setErr(null);
+                        setHasAddress(false);
+                      }
+                    }}
+                  />
+                  비공개
+                </label>
+              </div>
+              {unknownOfficeAddress ? (
+                <div className="rounded-200 flex h-10 w-full items-center border border-neutral-300 bg-neutral-100 px-3 text-neutral-400">
+                  비공개
+                </div>
+              ) : (
+                <DaumPostcodeButton
+                  onSelect={handleAddressSelect}
+                  address={
+                    hasAddress
+                      ? { city: officeAddr1, district: officeAddr2, town: officeAddr3 }
+                      : undefined
                   }
                 />
-                비공개
-              </label>
+              )}
             </div>
-          </div>
 
-          {/* 사무실 주소 */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              {/* 주소 라벨 */}
-              {renderLabel('사무실 주소', true)}
-
-              {/* 주소 검색 버튼 */}
-              <DaumPostcodeButton onSelect={handleAddressSelect} />
-            </div>
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                location_city
-              </span>
-              <div className="grid w-full grid-cols-3 gap-2">
-                <input
-                  disabled={unknownOfficeAddress}
-                  value={officeAddr1}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficeAddress ? '비공개' : '시/도'}
-                  type="text"
-                />
-                <input
-                  disabled={unknownOfficeAddress}
-                  value={officeAddr2}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficeAddress ? '비공개' : '시/군/구'}
-                  type="text"
-                />
-                <input
-                  disabled={unknownOfficeAddress}
-                  value={officeAddr3}
-                  readOnly
-                  onClick={handleAddressFieldClick}
-                  onFocus={handleAddressFieldClick}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficeAddress ? '비공개' : '읍/면/동'}
-                  type="text"
-                />
+            {/* 사무실 전화번호 */}
+            <div className="flex flex-col gap-2 border-b border-neutral-100 px-5 py-4">
+              <div className="flex items-center justify-between">
+                {renderLabel('사무실 전화번호', true)}
+                <label className="text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 cursor-pointer"
+                    checked={unknownOfficePhone}
+                    onChange={(e) => {
+                      if (e.target.checked) setOfficePhone('');
+                      setUnknownOfficePhone(e.target.checked);
+                    }}
+                  />
+                  비공개
+                </label>
               </div>
-              <label
+              <input
+                type="tel"
+                inputMode="numeric"
+                placeholder={unknownOfficePhone ? '비공개' : '02-1234-5678'}
+                value={officePhone}
+                onChange={(e) => setOfficePhone(formatPhone(e.target.value))}
+                disabled={unknownOfficePhone}
                 className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
+                  'rounded-200 h-10 w-full px-3',
+                  'border border-neutral-300',
+                  'disabled:bg-neutral-100 disabled:text-neutral-400',
+                  'focus:border-primary-400 focus:ring-primary-400 outline-none focus:ring-2',
                 ].join(' ')}
-              >
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
-                  checked={unknownOfficeAddress}
-                  onChange={(e) => {
-                    const checked = e.target.checked;
-
-                    handleCheckboxChange(
-                      checked,
-                      setUnknownOfficeAddress,
-                      setOfficeAddr1,
-                      setOfficeAddr2,
-                      setOfficeAddr3,
-                    );
-
-                    if (checked) {
-                      // "주소 모름"으로 바꾸면 주소 관련 에러는 지워준다
-                      setErr(null);
-                      setHasAddress(false); // 선택사항: 모름이면 hasAddress도 false로
-                    }
-                  }}
-                />
-                비공개
-              </label>
+                autoComplete="tel"
+              />
             </div>
-          </div>
 
-          {/* 사무실 전화번호 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('사무실 전화번호', true)}
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                call
-              </span>
-              <div className="grid w-full grid-cols-3 gap-2">
-                <input
-                  disabled={unknownOfficePhone}
-                  value={officeP1}
-                  onChange={(e) => setOfficeP1(e.target.value.replace(/\D/g, '').slice(0, 3))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficePhone ? '비공개' : '02'}
-                  inputMode="numeric"
-                />
-                <input
-                  disabled={unknownOfficePhone}
-                  value={officeP2}
-                  onChange={(e) => setOfficeP2(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficePhone ? '비공개' : '1234'}
-                  inputMode="numeric"
-                />
-                <input
-                  disabled={unknownOfficePhone}
-                  value={officeP3}
-                  onChange={(e) => setOfficeP3(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownOfficePhone ? '비공개' : '5678'}
-                  inputMode="numeric"
-                />
+            {/* 자택 전화번호 */}
+            <div className="flex flex-col gap-2 px-5 py-4">
+              <div className="flex items-center justify-between">
+                {renderLabel('자택 전화번호', true)}
+                <label className="text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 cursor-pointer"
+                    checked={unknownHomePhone}
+                    onChange={(e) => {
+                      if (e.target.checked) setHomePhone('');
+                      setUnknownHomePhone(e.target.checked);
+                    }}
+                  />
+                  비공개
+                </label>
               </div>
-              <label
+              <input
+                type="tel"
+                inputMode="numeric"
+                placeholder={unknownHomePhone ? '비공개' : '02-1234-5678'}
+                value={homePhone}
+                onChange={(e) => setHomePhone(formatPhone(e.target.value))}
+                disabled={unknownHomePhone}
                 className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
+                  'rounded-200 h-10 w-full px-3',
+                  'border border-neutral-300',
+                  'disabled:bg-neutral-100 disabled:text-neutral-400',
+                  'focus:border-primary-400 focus:ring-primary-400 outline-none focus:ring-2',
                 ].join(' ')}
-              >
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
-                  checked={unknownOfficePhone}
-                  onChange={(e) =>
-                    handleCheckboxChange(
-                      e.target.checked,
-                      setUnknownOfficePhone,
-                      setOfficeP1,
-                      setOfficeP2,
-                      setOfficeP3,
-                    )
-                  }
-                />
-                비공개
-              </label>
-            </div>
-          </div>
-
-          {/* 자택 전화번호 */}
-          <div className="flex flex-col gap-2">
-            {renderLabel('자택 전화번호', true)}
-            <div className="flex items-center gap-3">
-              <span
-                className="material-symbols-outlined text-primary-600/50"
-                style={{ fontSize: '24px' }}
-              >
-                home
-              </span>
-              <div className="grid w-full grid-cols-3 gap-2">
-                <input
-                  disabled={unknownHomePhone}
-                  value={homeP1}
-                  onChange={(e) => setHomeP1(e.target.value.replace(/\D/g, '').slice(0, 3))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownHomePhone ? '비공개' : '02'}
-                  inputMode="numeric"
-                />
-                <input
-                  disabled={unknownHomePhone}
-                  value={homeP2}
-                  onChange={(e) => setHomeP2(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownHomePhone ? '비공개' : '1234'}
-                  inputMode="numeric"
-                />
-                <input
-                  disabled={unknownHomePhone}
-                  value={homeP3}
-                  onChange={(e) => setHomeP3(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3 text-center',
-                    'border border-neutral-300',
-                    'disabled:bg-neutral-100 disabled:text-neutral-400',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
-                  placeholder={unknownHomePhone ? '비공개' : '5678'}
-                  inputMode="numeric"
-                />
-              </div>
-              <label
-                className={[
-                  'text-detail-regular inline-flex cursor-pointer items-center gap-2 text-neutral-700',
-                  'shrink-0 whitespace-nowrap',
-                ].join(' ')}
-              >
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 cursor-pointer"
-                  checked={unknownHomePhone}
-                  onChange={(e) =>
-                    handleCheckboxChange(
-                      e.target.checked,
-                      setUnknownHomePhone,
-                      setHomeP1,
-                      setHomeP2,
-                      setHomeP3,
-                    )
-                  }
-                />
-                비공개
-              </label>
+                autoComplete="tel"
+              />
             </div>
           </div>
         </div>

--- a/src/features/complaint/sections/ComplaintInfoSection.tsx
+++ b/src/features/complaint/sections/ComplaintInfoSection.tsx
@@ -1,18 +1,19 @@
 import type { AxiosError } from 'axios';
 
-import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import DaumPostcodeButton from '@/shared/ui/DaumPostcodeButton';
 import type { DaumPostcodeResult } from '@/shared/ui/DaumPostcodeButton';
 import FormErrorMessage from '@/shared/ui/FormErrorMessage';
 import IntroHeader from '@/shared/ui/IntroHeader';
 import Button from '@/shared/ui/common/Button';
-import { splitAddressTo3FromString, splitPhoneKR } from '@/shared/utils/krContact';
+import { splitAddressTo3FromString } from '@/shared/utils/krContact';
 
 import { getMe } from '@/features/auth/apis/auth';
 
-// 부모에서 사용할 타입
-export type ComplaintBasicInfo = {
+// 통합 타입
+export type ComplainantFullInfo = {
+  // basic
   name: string;
   email: string;
   address: string;
@@ -21,67 +22,145 @@ export type ComplaintBasicInfo = {
   unknownEmail: boolean;
   unknownAddr: boolean;
   unknownPhone: boolean;
+  // extra
+  occupation: string;
+  officeAddress: string;
+  officePhone: string;
+  homePhone: string;
+  unknownOccupation: boolean;
+  unknownOfficeAddress: boolean;
+  unknownOfficePhone: boolean;
+  unknownHomePhone: boolean;
 };
 
-// 부모 컴포넌트에서 save()를 직접 호출할 수 있도록 인터페이스 정의
+// 하위 호환을 위한 별칭
+export type ComplaintBasicInfo = ComplainantFullInfo;
+
 type Props = { onLoaded?: () => void };
 
 export type ComplainantInfoSectionHandle = {
-  save: () => Promise<ComplaintBasicInfo>;
+  save: () => Promise<ComplainantFullInfo>;
 };
 
 const ComplainantInfoSection = forwardRef<ComplainantInfoSectionHandle, Props>(
   ({ onLoaded }, ref) => {
     const formRef = useRef<HTMLFormElement>(null);
 
-    // 입력값 상태 관리
+    // 기본 정보 상태
     const [name, setName] = useState('');
     const [email, setEmail] = useState('');
     const [addr1, setAddr1] = useState('');
     const [addr2, setAddr2] = useState('');
     const [addr3, setAddr3] = useState('');
-    const [p1, setP1] = useState('');
-    const [p2, setP2] = useState('');
-    const [p3, setP3] = useState('');
-
-    // UI 상태 관리
-    const [err, setErr] = useState<string | null>(null); // 에러 메시지만 유지
-
+    const [phone, setPhone] = useState('');
     const [hasAddress, setHasAddress] = useState(false);
 
-    // 주소 필드 클릭 시 에러 띄우기
-    const handleAddressFieldClick = () => {
-      if (!hasAddress) {
-        setErr('주소 찾기 버튼을 눌러 주소를 선택해주세요.');
+    // 추가 정보 상태
+    const [occupation, setOccupation] = useState('');
+    const [officeAddr1, setOfficeAddr1] = useState('');
+    const [officeAddr2, setOfficeAddr2] = useState('');
+    const [officeAddr3, setOfficeAddr3] = useState('');
+    const [officePhone, setOfficePhone] = useState('');
+    const [homePhone, setHomePhone] = useState('');
+    const [hasOfficeAddress, setHasOfficeAddress] = useState(false);
+
+    // 비공개 토글
+    const [unknownOccupation, setUnknownOccupation] = useState(false);
+    const [unknownOfficeAddress, setUnknownOfficeAddress] = useState(false);
+    const [unknownOfficePhone, setUnknownOfficePhone] = useState(false);
+    const [unknownHomePhone, setUnknownHomePhone] = useState(false);
+
+    const allExtraPrivate =
+      unknownOccupation && unknownOfficeAddress && unknownOfficePhone && unknownHomePhone;
+
+    const handleToggleAllExtra = (checked: boolean) => {
+      setUnknownOccupation(checked);
+      setUnknownOfficeAddress(checked);
+      setUnknownOfficePhone(checked);
+      setUnknownHomePhone(checked);
+      if (checked) {
+        setOccupation('');
+        setOfficeAddr1('');
+        setOfficeAddr2('');
+        setOfficeAddr3('');
+        setOfficePhone('');
+        setHomePhone('');
+        setHasOfficeAddress(false);
       }
     };
 
-    // 주소 선택 콜백 (다음 API에서 선택되면 호출)
+    // UI 상태
+    const [err, setErr] = useState<string | null>(null);
+
+    // 주소 선택 콜백 (기본)
     const handleAddressSelect = (data: DaumPostcodeResult) => {
-      const { a1, a2, a3 } = splitAddressTo3FromString(data.roadAddress);
-      setAddr1(a1);
-      setAddr2(a2);
-      setAddr3(a3);
+      setAddr1(data.sido);
+      setAddr2(data.sigungu);
+      setAddr3(data.bname);
       setHasAddress(true);
       setErr(null);
     };
 
-    const renderLabel = (text: string, required: boolean) => {
-      const labelText = required ? '(필수)' : '(선택)';
-      return (
-        <label className="text-body-3-regular text-neutral-900">
-          <span
-            className={
-              required
-                ? 'text-detail-bold text-positive-200 mr-4'
-                : 'text-detail-bold mr-2 text-neutral-500'
-            }
-          >
-            {labelText}
-          </span>
-          {text}
-        </label>
-      );
+    // 주소 선택 콜백 (사무실)
+    const handleOfficeAddressSelect = (data: DaumPostcodeResult) => {
+      setOfficeAddr1(data.sido);
+      setOfficeAddr2(data.sigungu);
+      setOfficeAddr3(data.bname);
+      setHasOfficeAddress(true);
+      setUnknownOfficeAddress(false);
+      setErr(null);
+    };
+
+    // 전화번호 포맷팅
+    const formatPhone = (value: string) => {
+      const digits = value.replace(/\D/g, '').slice(0, 11);
+      if (digits.length <= 3) return digits;
+      if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+      return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+    };
+
+    const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setPhone(formatPhone(e.target.value));
+    };
+
+    const handleOfficePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setOfficePhone(formatPhone(e.target.value));
+    };
+
+    const handleHomePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setHomePhone(formatPhone(e.target.value));
+    };
+
+    const phoneDigits = phone.replace(/\D/g, '');
+    const officePhoneDigits = officePhone.replace(/\D/g, '');
+
+    // 입력값 변경 시 에러 자동 해제
+    useEffect(() => {
+      if (err) setErr(null);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+      name,
+      email,
+      phone,
+      addr1,
+      occupation,
+      officePhone,
+      homePhone,
+      officeAddr1,
+      unknownOccupation,
+      unknownOfficeAddress,
+      unknownOfficePhone,
+      unknownHomePhone,
+    ]);
+    const homePhoneDigits = homePhone.replace(/\D/g, '');
+
+    const handleCheckboxChange = (
+      checked: boolean,
+      setFlag: React.Dispatch<React.SetStateAction<boolean>>,
+      ...setters: React.Dispatch<React.SetStateAction<string>>[]
+    ) => {
+      setFlag(checked);
+      if (checked) setters.forEach((setter) => setter(''));
     };
 
     // 내 정보 불러오기
@@ -101,10 +180,7 @@ const ComplainantInfoSection = forwardRef<ComplainantInfoSectionHandle, Props>(
 
         setHasAddress(Boolean(a1));
 
-        const { p1: _1, p2: _2, p3: _3 } = splitPhoneKR(me.phone_number);
-        setP1(_1);
-        setP2(_2);
-        setP3(_3);
+        setPhone(formatPhone(me.phone_number ?? ''));
       } catch (e: unknown) {
         const ax = e as AxiosError | undefined;
         const status = ax?.response?.status;
@@ -114,36 +190,69 @@ const ComplainantInfoSection = forwardRef<ComplainantInfoSectionHandle, Props>(
       }
     };
 
-    // 기본 정보 객체 만들기
-    const buildBasicInfo = (): ComplaintBasicInfo => {
+    // 통합 정보 빌드
+    const buildFullInfo = (): ComplainantFullInfo => {
       setErr(null);
 
       if (!name.trim()) {
-        const msg = '필수 항목을 입력해주세요.';
+        const msg = '이름을 입력해주세요.';
+        setErr(msg);
+        throw new Error(msg);
+      }
+
+      // 추가 정보 검증: 입력하거나 비공개 선택해야 함
+      if (!unknownOccupation && !occupation.trim()) {
+        const msg = '직업을 입력하거나 비공개를 선택해주세요.';
+        setErr(msg);
+        throw new Error(msg);
+      }
+      if (!unknownOfficeAddress && !officeAddr1) {
+        const msg = '사무실 주소를 입력하거나 비공개를 선택해주세요.';
+        setErr(msg);
+        throw new Error(msg);
+      }
+      if (!unknownOfficePhone && officePhoneDigits.length < 9) {
+        const msg = '사무실 전화번호를 입력하거나 비공개를 선택해주세요.';
+        setErr(msg);
+        throw new Error(msg);
+      }
+      if (!unknownHomePhone && homePhoneDigits.length < 9) {
+        const msg = '자택 전화번호를 입력하거나 비공개를 선택해주세요.';
         setErr(msg);
         throw new Error(msg);
       }
 
       const address = [addr1, addr2, addr3].filter(Boolean).join(' ').trim();
-      const phone = [p1, p2, p3].join('-').replace(/--+/g, '-').trim();
+      const officeAddress = unknownOfficeAddress
+        ? '비공개'
+        : [officeAddr1, officeAddr2, officeAddr3].filter(Boolean).join(' ').trim();
 
       return {
+        // basic
         name: name.trim(),
         email: email.trim(),
         address,
-        phone,
-        // 아직 "모름/비공개" 체크 UI가 없으니 기본값은 false
+        phone: phoneDigits,
         unknownName: false,
         unknownEmail: false,
         unknownAddr: false,
         unknownPhone: false,
+        // extra
+        occupation: unknownOccupation ? '비공개' : occupation.trim(),
+        officeAddress,
+        officePhone: unknownOfficePhone ? '비공개' : officePhoneDigits,
+        homePhone: unknownHomePhone ? '비공개' : homePhoneDigits,
+        unknownOccupation,
+        unknownOfficeAddress,
+        unknownOfficePhone,
+        unknownHomePhone,
       };
     };
 
     useImperativeHandle(ref, () => ({
       save: async () => {
         try {
-          const info = buildBasicInfo();
+          const info = buildFullInfo();
           return info;
         } catch (e: unknown) {
           const msg = (e as { message?: string })?.message ?? '에러가 발생했습니다.';
@@ -156,31 +265,58 @@ const ComplainantInfoSection = forwardRef<ComplainantInfoSectionHandle, Props>(
     const handleSubmit = (e: React.FormEvent) => {
       e.preventDefault();
       try {
-        const info = buildBasicInfo();
-        // 이 폼에서 직접 submit 버튼 눌렀을 때도 onLoaded 호출할지 여부는 선택
+        const info = buildFullInfo();
         onLoaded?.();
-        // submit 시에는 그냥 검증 성공만 해도 되기 때문에 추가 동작은 선택사항
-        void info; // eslint 안 쓰게 한줄
+        void info;
       } catch {
-        // 에러는 buildBasicInfo 안에서 setErr로 처리됨
+        // 에러는 buildFullInfo 안에서 setErr로 처리됨
       }
     };
 
+    // ID 카드 미리보기용 헬퍼
+    const renderIdCardField = (
+      label: string,
+      value: string,
+      hasValue: boolean,
+      isPrivate?: boolean,
+    ) => (
+      <div className="col-span-1">
+        <p className="text-detail-regular text-neutral-400">{label}</p>
+        {isPrivate ? (
+          <p className="text-body-3-bold text-neutral-400 italic">비공개</p>
+        ) : (
+          <p
+            className={`text-body-3-bold transition-colors ${hasValue ? 'text-neutral-900' : 'text-neutral-300'}`}
+          >
+            {value || '---'}
+          </p>
+        )}
+      </div>
+    );
+
+    const inputClass = [
+      'rounded-200 h-9 w-full px-3',
+      'border border-neutral-300',
+      'text-body-3-regular',
+      'focus:border-primary-400 focus:ring-primary-400 outline-none focus:ring-2',
+    ].join(' ');
+
+    const disabledInputClass = [
+      inputClass,
+      'disabled:bg-neutral-100 disabled:text-neutral-400',
+    ].join(' ');
+
     return (
       <section
-        className={[
-          'flex flex-col items-center justify-between',
-          'h-[600px] w-full max-w-[1000px]',
-          'pb-6',
-          'bg-neutral-0',
-        ].join(' ')}
+        className={['flex flex-col items-center', 'w-full flex-1', 'pb-6', 'bg-neutral-0'].join(
+          ' ',
+        )}
       >
         <IntroHeader
           title="고소장 작성하기"
           lines={[
             '고소장을 작성하려면 내 정보를 적어야 해요.',
-            '로그인 시 입력한 정보를 불러올 수도 있고,',
-            '직접 입력할 수도 있어요.',
+            '로그인 시 입력한 정보를 불러올 수도 있고, 직접 입력할 수도 있어요.',
           ]}
           center
           showArrow
@@ -189,190 +325,269 @@ const ComplainantInfoSection = forwardRef<ComplainantInfoSectionHandle, Props>(
         <form
           ref={formRef}
           onSubmit={handleSubmit}
-          className="mt-2 flex w-[420px] flex-col gap-5"
+          className="mt-2 flex w-full flex-1 flex-col items-center justify-center gap-6"
         >
-          {/* 내 정보 불러오기 버튼 */}
-          <div className="flex justify-end">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleLoadFromProfile}
-            >
-              내 정보 불러오기
-            </Button>
+          {/* ID 카드 미리보기 */}
+          <div className="w-full max-w-[520px]">
+            <div className="border-primary-200 from-primary-0 overflow-hidden rounded-2xl border bg-gradient-to-br to-white shadow-sm">
+              {/* 카드 상단 바 */}
+              <div className="bg-primary-400 flex items-center justify-between px-5 py-2.5">
+                <div className="flex items-center gap-2">
+                  <span
+                    className="material-symbols-outlined text-white/80"
+                    style={{ fontSize: '16px' }}
+                  >
+                    badge
+                  </span>
+                  <span className="text-detail-bold text-white/90">고소인 정보</span>
+                </div>
+              </div>
+
+              {/* 카드 본문 - 기본 정보 */}
+              <div className="grid grid-cols-2 gap-x-6 gap-y-3 border-b border-neutral-100 px-5 py-4">
+                {renderIdCardField('이름', name, Boolean(name))}
+                {renderIdCardField('전화번호', phone, Boolean(phone))}
+                {renderIdCardField('이메일', email, Boolean(email))}
+                {renderIdCardField(
+                  '주소',
+                  hasAddress ? [addr1, addr2, addr3].filter(Boolean).join(' ') : '',
+                  hasAddress,
+                )}
+              </div>
+
+              {/* 카드 본문 - 추가 정보 */}
+              <div className="grid grid-cols-2 gap-x-6 gap-y-3 px-5 py-4">
+                {renderIdCardField('직업', occupation, Boolean(occupation), unknownOccupation)}
+                {renderIdCardField(
+                  '사무실 전화번호',
+                  officePhone,
+                  Boolean(officePhone),
+                  unknownOfficePhone,
+                )}
+                {renderIdCardField(
+                  '사무실 주소',
+                  hasOfficeAddress
+                    ? [officeAddr1, officeAddr2, officeAddr3].filter(Boolean).join(' ')
+                    : '',
+                  hasOfficeAddress,
+                  unknownOfficeAddress,
+                )}
+                {renderIdCardField(
+                  '자택 전화번호',
+                  homePhone,
+                  Boolean(homePhone),
+                  unknownHomePhone,
+                )}
+              </div>
+            </div>
           </div>
 
-          {/* 입력 필드들 */}
-          <div className="flex flex-1 flex-col justify-center gap-5 px-5">
-            {/* 이름 */}
-            <div className="flex flex-col gap-2">
-              {renderLabel('이름', true)}
-              <div className="flex items-center gap-4">
-                <span
-                  className="material-symbols-outlined text-primary-600/50"
-                  style={{ fontSize: '24px' }}
+          {/* 입력 폼 카드 */}
+          <div className="w-full max-w-[520px]">
+            <div className="max-h-[480px] overflow-y-auto rounded-2xl border border-neutral-200 bg-white shadow-sm">
+              {/* 기본 정보 서브헤더 */}
+              <div className="flex items-center justify-between border-b border-neutral-100 bg-neutral-50 px-5 py-3">
+                <span className="text-detail-bold text-neutral-500">기본 정보</span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  onClick={handleLoadFromProfile}
                 >
-                  person
-                </span>
+                  내 정보 불러오기
+                </Button>
+              </div>
+
+              {/* 이름 */}
+              <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">이름</span>
                 <input
                   id="name"
                   type="text"
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3',
-                    'border border-neutral-300',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
+                  className={`flex-1 ${inputClass}`}
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   autoComplete="name"
                   placeholder="홍길동"
                 />
               </div>
-            </div>
 
-            {/* 이메일 */}
-            <div className="flex flex-col gap-2">
-              {renderLabel('이메일', false)} {/* 필수로 바꾸고 싶으면 true */}
-              <div className="flex items-center gap-4">
-                <span
-                  className="material-symbols-outlined text-primary-600/50"
-                  style={{ fontSize: '24px' }}
-                >
-                  email
-                </span>
+              {/* 이메일 */}
+              <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">이메일</span>
                 <input
                   id="email"
                   type="email"
-                  className={[
-                    'rounded-200 h-10 flex-1 px-3',
-                    'border border-neutral-300',
-                    'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                  ].join(' ')}
+                  className={`flex-1 ${inputClass}`}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   autoComplete="email"
                   placeholder="example@email.com"
                 />
               </div>
-            </div>
 
-            {/* 주소 */}
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                {/* 주소 라벨 */}
-                {renderLabel('주소', true)}
-
-                {/* 주소 검색 버튼 */}
-                <DaumPostcodeButton onSelect={handleAddressSelect} />
+              {/* 전화번호 */}
+              <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">전화번호</span>
+                <input
+                  id="phone"
+                  type="tel"
+                  inputMode="numeric"
+                  placeholder="010-1234-5678"
+                  value={phone}
+                  onChange={handlePhoneChange}
+                  className={`flex-1 ${inputClass}`}
+                  autoComplete="tel"
+                />
               </div>
-              <div className="flex items-center gap-4">
-                <span
-                  className="material-symbols-outlined text-primary-600/50"
-                  style={{ fontSize: '24px' }}
-                >
-                  location_on
-                </span>
-                <div className="grid w-full grid-cols-3 gap-2">
-                  <input
-                    id="addr1"
-                    value={addr1}
-                    readOnly
-                    onClick={handleAddressFieldClick}
-                    onFocus={handleAddressFieldClick}
-                    onChange={(e) => setAddr1(e.target.value)}
-                    className={[
-                      'rounded-200 h-10 flex-1 px-3 text-center',
-                      'border border-neutral-300',
-                      'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                    ].join(' ')}
-                    placeholder="시/도"
-                  />
-                  <input
-                    id="addr2"
-                    value={addr2}
-                    readOnly
-                    onClick={handleAddressFieldClick}
-                    onFocus={handleAddressFieldClick}
-                    onChange={(e) => setAddr2(e.target.value)}
-                    className={[
-                      'rounded-200 h-10 flex-1 px-3 text-center',
-                      'border border-neutral-300',
-                      'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                    ].join(' ')}
-                    placeholder="시/군/구"
-                  />
-                  <input
-                    id="addr3"
-                    value={addr3}
-                    readOnly
-                    onClick={handleAddressFieldClick}
-                    onFocus={handleAddressFieldClick}
-                    onChange={(e) => setAddr3(e.target.value)}
-                    className={[
-                      'rounded-200 h-10 flex-1 px-3 text-center',
-                      'border border-neutral-300',
-                      'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                    ].join(' ')}
-                    placeholder="읍/면/동"
+
+              {/* 주소 */}
+              <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">주소</span>
+                <div className="flex-1">
+                  <DaumPostcodeButton
+                    onSelect={handleAddressSelect}
+                    address={hasAddress ? { city: addr1, district: addr2, town: addr3 } : undefined}
                   />
                 </div>
               </div>
-            </div>
 
-            {/* 연락처 */}
-            <div className="flex flex-col gap-2">
-              {renderLabel('전화번호', true)}
-              <div className="flex items-center gap-4">
-                <span
-                  className="material-symbols-outlined text-primary-600/50"
-                  style={{ fontSize: '24px' }}
-                >
-                  phone_in_talk
-                </span>
-                <div className="grid w-full grid-cols-3 gap-2">
+              {/* 추가 정보 구분선 */}
+              <div className="flex items-center justify-between border-b border-neutral-100 bg-neutral-50 px-5 py-3">
+                <span className="text-detail-bold text-neutral-500">추가 정보</span>
+                <label className="text-detail-regular inline-flex cursor-pointer items-center gap-1.5 text-neutral-500">
                   <input
-                    id="phone1"
-                    maxLength={3}
-                    value={p1}
-                    onChange={(e) => setP1(e.target.value.replace(/\D/g, '').slice(0, 3))}
-                    className={[
-                      'rounded-200 h-10 flex-1 px-3 text-center',
-                      'border border-neutral-300',
-                      'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                    ].join(' ')}
-                    placeholder="010"
-                    inputMode="numeric"
+                    type="checkbox"
+                    className="h-3.5 w-3.5 cursor-pointer"
+                    checked={allExtraPrivate}
+                    onChange={(e) => handleToggleAllExtra(e.target.checked)}
                   />
+                  전체 비공개
+                </label>
+              </div>
+
+              {/* 직업 */}
+              <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">직업</span>
+                <input
+                  disabled={unknownOccupation}
+                  value={occupation}
+                  onChange={(e) => setOccupation(e.target.value)}
+                  className={`flex-1 ${disabledInputClass}`}
+                  placeholder={unknownOccupation ? '비공개' : '예: 회사원, 자영업자 등'}
+                  type="text"
+                />
+                <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
                   <input
-                    id="phone2"
-                    maxLength={4}
-                    value={p2}
-                    onChange={(e) => setP2(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                    className={[
-                      'rounded-200 h-10 flex-1 px-3 text-center',
-                      'border border-neutral-300',
-                      'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                    ].join(' ')}
-                    placeholder="1234"
-                    inputMode="numeric"
+                    type="checkbox"
+                    className="h-3.5 w-3.5 cursor-pointer"
+                    checked={unknownOccupation}
+                    onChange={(e) =>
+                      handleCheckboxChange(e.target.checked, setUnknownOccupation, setOccupation)
+                    }
                   />
-                  <input
-                    id="phone3"
-                    maxLength={4}
-                    value={p3}
-                    onChange={(e) => setP3(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                    className={[
-                      'rounded-200 h-10 flex-1 px-3 text-center',
-                      'border border-neutral-300',
-                      'focus:border-primary-400 focus:ring-primary-0 outline-none focus:ring-2',
-                    ].join(' ')}
-                    placeholder="5678"
-                    inputMode="numeric"
-                  />
+                  비공개
+                </label>
+              </div>
+
+              {/* 사무실 주소 */}
+              <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">사무실 주소</span>
+                <div className="flex-1">
+                  {unknownOfficeAddress ? (
+                    <div className="rounded-200 flex h-9 w-full items-center border border-neutral-300 bg-neutral-100 px-3 text-neutral-400">
+                      비공개
+                    </div>
+                  ) : (
+                    <DaumPostcodeButton
+                      onSelect={handleOfficeAddressSelect}
+                      address={
+                        hasOfficeAddress
+                          ? { city: officeAddr1, district: officeAddr2, town: officeAddr3 }
+                          : undefined
+                      }
+                    />
+                  )}
                 </div>
+                <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
+                  <input
+                    type="checkbox"
+                    className="h-3.5 w-3.5 cursor-pointer"
+                    checked={unknownOfficeAddress}
+                    onChange={(e) => {
+                      handleCheckboxChange(
+                        e.target.checked,
+                        setUnknownOfficeAddress,
+                        setOfficeAddr1,
+                        setOfficeAddr2,
+                        setOfficeAddr3,
+                      );
+                      if (e.target.checked) {
+                        setErr(null);
+                        setHasOfficeAddress(false);
+                      }
+                    }}
+                  />
+                  비공개
+                </label>
+              </div>
+
+              {/* 사무실 전화번호 */}
+              <div className="flex items-center gap-4 border-b border-neutral-100 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">사무실 번호</span>
+                <input
+                  type="tel"
+                  inputMode="numeric"
+                  placeholder={unknownOfficePhone ? '비공개' : '02-1234-5678'}
+                  value={officePhone}
+                  onChange={handleOfficePhoneChange}
+                  disabled={unknownOfficePhone}
+                  className={`flex-1 ${disabledInputClass}`}
+                  autoComplete="tel"
+                />
+                <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
+                  <input
+                    type="checkbox"
+                    className="h-3.5 w-3.5 cursor-pointer"
+                    checked={unknownOfficePhone}
+                    onChange={(e) => {
+                      if (e.target.checked) setOfficePhone('');
+                      setUnknownOfficePhone(e.target.checked);
+                    }}
+                  />
+                  비공개
+                </label>
+              </div>
+
+              {/* 자택 전화번호 */}
+              <div className="flex items-center gap-4 px-5 py-3">
+                <span className="text-body-3-bold w-20 shrink-0 text-neutral-600">자택 번호</span>
+                <input
+                  type="tel"
+                  inputMode="numeric"
+                  placeholder={unknownHomePhone ? '비공개' : '02-1234-5678'}
+                  value={homePhone}
+                  onChange={handleHomePhoneChange}
+                  disabled={unknownHomePhone}
+                  className={`flex-1 ${disabledInputClass}`}
+                  autoComplete="tel"
+                />
+                <label className="text-detail-regular inline-flex shrink-0 cursor-pointer items-center gap-1 text-neutral-500">
+                  <input
+                    type="checkbox"
+                    className="h-3.5 w-3.5 cursor-pointer"
+                    checked={unknownHomePhone}
+                    onChange={(e) => {
+                      if (e.target.checked) setHomePhone('');
+                      setUnknownHomePhone(e.target.checked);
+                    }}
+                  />
+                  비공개
+                </label>
               </div>
             </div>
           </div>
+
           {/* 에러 메시지 */}
           <FormErrorMessage error={err} />
         </form>

--- a/src/features/complaint/sections/ComplaintIntroSection.tsx
+++ b/src/features/complaint/sections/ComplaintIntroSection.tsx
@@ -18,8 +18,8 @@ const ComplaintIntroSection: React.FC = () => {
   return (
     <section
       className={[
-        'flex flex-col items-center justify-between',
-        'h-[600px] w-full max-w-[1000px]',
+        'flex flex-col items-center',
+        'w-full flex-1',
         'pb-6',
         'bg-neutral-0 rounded-400',
       ].join(' ')}
@@ -28,28 +28,37 @@ const ComplaintIntroSection: React.FC = () => {
         title="고소장 작성하기"
         lines={[
           '고소장 작성 전에 확인해야 할 것들이 있어요.',
-          '원활한 고소장 접수를 위해서',
-          '솔직하게 체크해주세요.',
+          '원활한 고소장 접수를 위해서 솔직하게 체크해주세요.',
         ]}
         center
         showArrow
       />
 
-      <div className="flex flex-col gap-5 pt-6">
-        {prechecks.map((q) => (
-          <Question
-            key={q.id}
-            q={q}
-            onToggleConfirm={toggleConfirm}
-            onSetBinary={setBinaryAnswer}
-            forceOpenInfo={q.id === blockedPrecheckId}
-          />
-        ))}
+      <div className="flex w-full max-w-[520px] flex-1 flex-col items-center justify-center">
+        <div className="rounded-300 w-full border border-neutral-200 bg-white shadow-sm">
+          {prechecks.map((q, idx) => (
+            <Question
+              key={q.id}
+              q={q}
+              onToggleConfirm={toggleConfirm}
+              onSetBinary={setBinaryAnswer}
+              forceOpenInfo={q.id === blockedPrecheckId}
+              isLast={idx === prechecks.length - 1}
+            />
+          ))}
+        </div>
       </div>
 
       {/* 경고 문구 */}
       <FormErrorMessage
-        error={triedNext && !allChecked ? '모든 안내 사항을 꼼꼼히 읽고 체크해주세요.' : null}
+        className="mt-4"
+        error={
+          triedNext && blockedPrecheckId
+            ? '해당 항목에 "예"라고 답하셨어요. 이 경우 고소장 작성이 어려울 수 있으니, 법률 전문가와 먼저 상담해보시는 걸 추천드려요.'
+            : triedNext && !allChecked
+              ? '모든 항목을 확인하고 체크해주세요.'
+              : null
+        }
       />
     </section>
   );

--- a/src/features/complaint/sections/ComplaintPreviewSection.tsx
+++ b/src/features/complaint/sections/ComplaintPreviewSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import IntroHeader from '@/shared/ui/IntroHeader';
 
@@ -7,50 +7,45 @@ type ComplaintPreviewSectionProps = {
   content: string;
 };
 
-// 섹션 타이틀을 감지해서 스타일 적용하는 함수
 function renderStyledContent(text: string) {
   const lines = text.split('\n');
 
   return lines.map((line, idx) => {
     const trimmed = line.trim();
 
-    // 공백 줄 → 살짝 여백만 추가
     if (!trimmed) {
       return (
         <div
           key={idx}
-          className="h-2"
+          className="h-3"
         />
       );
     }
 
     // 섹션 제목: [범죄 사실], [고소 이유]
-    if (trimmed === '[범죄 사실]' || trimmed === '[고소 이유]') {
-      const title = trimmed.replace(/^\[|\]$/g, ''); // 대괄호 제거
-
+    if (/^\[.+\]$/.test(trimmed)) {
+      const title = trimmed.replace(/^\[|\]$/g, '');
       return (
         <div
           key={idx}
-          className="text-heading-3-bold mt-6 mb-3 text-center text-neutral-900"
+          className="mt-6 mb-3 flex items-center gap-2"
         >
-          {title}
+          <div className="bg-primary-400 h-5 w-1 rounded-full" />
+          <span className="text-body-2-bold text-neutral-900">{title}</span>
         </div>
       );
     }
 
-    // 불릿 문단: "○ ..." 로 시작하는 줄
+    // 불릿 문단
     if (trimmed.startsWith('○')) {
       const body = trimmed.replace(/^○\s*/, '');
-
       return (
         <div
           key={idx}
-          className="mb-2 flex items-start gap-2"
+          className="mb-2 flex items-start gap-2 pl-3"
         >
-          <span className="text-primary-200 mt-[6px] text-[8px]">●</span>
-          <p className="text-body-2-regular leading-relaxed break-words whitespace-pre-wrap text-neutral-800">
-            {body}
-          </p>
+          <span className="bg-primary-300 mt-2 h-1.5 w-1.5 shrink-0 rounded-full" />
+          <p className="text-body-3-regular leading-relaxed text-neutral-700">{body}</p>
         </div>
       );
     }
@@ -59,152 +54,55 @@ function renderStyledContent(text: string) {
     return (
       <p
         key={idx}
-        className="text-body-2-regular leading-relaxed break-words whitespace-pre-wrap text-neutral-800"
+        className="text-body-3-regular leading-relaxed text-neutral-700"
       >
         {line}
       </p>
     );
   });
 }
+
 const ComplaintPreviewSection: React.FC<ComplaintPreviewSectionProps> = ({
   complaintId,
   content,
 }) => {
-  // 전체 화면 모드 상태
-  const [isFullscreen, setIsFullscreen] = useState(false);
-
   return (
-    <>
-      {/* 기본 미리보기 (카드 버전) */}
-      <section
-        aria-label={`고소장 미리보기 (ID: ${complaintId})`}
-        className={[
-          'balaw-scrollbar flex flex-col items-center justify-between',
-          'mx-auto h-[600px] w-full max-w-[600px]',
-          'bg-neutral-0 gap-5 pt-6 pb-6',
-        ].join(' ')}
-      >
-        <IntroHeader
-          title="완성된 고소장 미리 보기"
-          lines={[
-            '바로가 완성한 고소장 초안이에요.',
-            '모두 정확히 작성 됐는지 확인해보고,',
-            '다음으로 넘어가서 다운로드 받아 보세요.',
-          ]}
-          center
-          showArrow
-        />
+    <section
+      aria-label={`고소장 미리보기 (ID: ${complaintId})`}
+      className="mx-auto flex w-full max-w-[640px] flex-1 flex-col gap-4"
+    >
+      <IntroHeader
+        title="완성된 고소장 미리 보기"
+        lines={[
+          '바로가 완성한 고소장 초안이에요.',
+          '모두 정확히 작성 됐는지 확인해보고, 다음으로 넘어가서 다운로드 받아 보세요.',
+        ]}
+        center
+        showArrow
+      />
 
-        {/* 문서 카드 */}
-        <div
-          className={[
-            'flex min-h-0 w-full flex-1 flex-col',
-            'rounded-200 bg-neutral-0 border border-neutral-200 shadow-sm',
-            'px-5 py-4',
-          ].join(' ')}
-        >
-          {/* 카드 헤더 (ID / 상태 뱃지) */}
-          <div className="mb-3 flex items-center justify-between gap-2">
-            <div className="flex w-full items-center justify-between">
-              <span className="text-caption-regular text-neutral-500">고소장 초안</span>
-              <span className="text-body-3-bold text-neutral-900">문서 ID #{complaintId}</span>
-            </div>
-
-            {/* 전체 화면 버튼 */}
-            <button
-              type="button"
-              onClick={() => setIsFullscreen(true)}
-              className="group hover:text-primary-400 relative text-neutral-400 transition-colors"
+      {/* 문서 카드 */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+        {/* 카드 헤더 */}
+        <div className="flex shrink-0 items-center justify-between border-b border-neutral-100 px-5 py-3">
+          <div className="flex items-center gap-2">
+            <span
+              className="material-symbols-outlined text-primary-400"
+              style={{ fontSize: '20px' }}
             >
-              <span
-                className="material-symbols-outlined"
-                style={{ fontSize: '16px' }}
-              >
-                open_in_full
-              </span>
-
-              {/* 툴팁 */}
-              <div
-                className={[
-                  'absolute top-full left-1/2 mt-1 -translate-x-1/2',
-                  'rounded-200 bg-primary-0/50 px-2 py-1',
-                  'text-detail-regular whitespace-nowrap text-neutral-500',
-                  'opacity-0 transition-opacity duration-200',
-                  'pointer-events-none',
-                  'group-hover:opacity-100',
-                ].join(' ')}
-              >
-                {' '}
-                전체 보기
-              </div>
-            </button>
-          </div>
-
-          {/* 구분선 */}
-          <div className="mb-3 h-px w-full bg-neutral-100" />
-
-          {/* 실제 내용 스크롤 영역 */}
-          <div
-            className={[
-              'relative min-h-0 flex-1',
-              'overflow-y-auto',
-              'pr-3', // 스크롤바 여유
-            ].join(' ')}
-          >
-            <div className={['relative min-h-0 flex-1', 'overflow-y-auto', 'pr-3'].join(' ')}>
-              {renderStyledContent(content)}
-            </div>
+              description
+            </span>
+            <span className="text-body-3-bold text-neutral-800">고소장 초안</span>
+            <span className="text-detail-regular text-neutral-400">#{complaintId}</span>
           </div>
         </div>
-      </section>
 
-      {/* 전체 화면 모달 */}
-      {isFullscreen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/60 px-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label="고소장 전체 화면 미리보기"
-        >
-          <div
-            className={[
-              'balaw-scrollbar flex max-h-[90vh] w-full max-w-4xl flex-col',
-              'rounded-400 bg-neutral-0',
-              'px-8 py-6',
-              'shadow-[0_16px_40px_rgba(15,23,42,0.35)]',
-            ].join(' ')}
-          >
-            {/* 상단 헤더 (제목 + 닫기 버튼) */}
-            <div className="mb-4 flex items-center justify-between gap-3">
-              <div className="flex flex-col">
-                <span className="text-caption-regular text-neutral-500">고소장 전체 미리보기</span>
-                <span className="text-body-1-bold text-neutral-900">문서 ID #{complaintId}</span>
-              </div>
-              <button
-                type="button"
-                onClick={() => setIsFullscreen(false)}
-                className="hover:text-warning-300 text-neutral-400 transition-colors"
-              >
-                <span
-                  className="material-symbols-outlined"
-                  style={{ fontSize: '16px' }}
-                >
-                  close
-                </span>
-              </button>
-            </div>
-
-            {/* 구분선 */}
-            <div className="mb-4 h-px w-full bg-neutral-100" />
-
-            {/* 내용 스크롤 영역 (더 넓고 더 높은 영역) */}
-            <div className="balaw-scrollbar min-h-0 flex-1 overflow-y-auto pr-4">
-              {renderStyledContent(content)}
-            </div>
-          </div>
+        {/* 문서 본문 */}
+        <div className="balaw-scrollbar min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {renderStyledContent(content)}
         </div>
-      )}
-    </>
+      </div>
+    </section>
   );
 };
 

--- a/src/features/complaint/sections/EvidenceInfoSection.tsx
+++ b/src/features/complaint/sections/EvidenceInfoSection.tsx
@@ -35,109 +35,166 @@ const EvidenceInfoSection = forwardRef<EvidenceInfoSectionHandle>((_props, ref) 
 
   return (
     <section
-      className={[
-        'flex flex-col items-center justify-between',
-        'h-[600px] w-full max-w-[1000px]',
-        'pb-6',
-        'bg-neutral-0',
-      ].join(' ')}
+      className={['flex flex-col items-center', 'w-full flex-1', 'pb-6', 'bg-neutral-0'].join(' ')}
     >
       <IntroHeader
         title="증거 유무 확인"
         lines={[
           '확보한 증거들이 있나요?',
-          '증거 확보 유무만 체크해주고,',
-          '확보한 증거가 있다면 따로 관할서에 제출하면 돼요.',
+          '증거 확보 유무만 체크해주고, 확보한 증거가 있다면 따로 관할서에 제출하면 돼요.',
         ]}
         center
         showArrow
       />
-      <div className="mt-5 flex flex-col gap-3">
+
+      <div className="mx-auto grid w-full max-w-[520px] flex-1 grid-cols-1 place-content-center gap-4 px-4 md:grid-cols-2 md:gap-6">
+        {/* 네, 증거가 있어요 */}
         <button
           type="button"
-          onClick={() => setSelection('yes')}
+          onClick={() => {
+            setSelection('yes');
+            setError(null);
+          }}
           className={[
-            'rounded-300 flex w-full items-center gap-2 border px-4 py-3 text-left',
-            // ghost base
-            'to-neutral-0/10 bg-radial from-neutral-200/40 via-neutral-100/10',
-            'border',
-            'shadow-[inset_0_1px_2px_rgba(255,255,255,0.12)]',
-            'backdrop-blur-md',
-            'transition-all duration-300 ease-out',
-            // active vs default
+            'group relative flex w-full flex-col items-center justify-center gap-4',
+            'rounded-300 px-6 py-10',
+            'border-2 bg-white',
+            'transition-all duration-200 ease-out',
             isYesActive
-              ? 'border-primary-300 ring-primary-200 ring-2'
-              : 'hover:ring-primary-50/40 border-white/50 hover:border-white/70 hover:ring-2',
+              ? 'border-primary-400 bg-primary-0/30 shadow-[0_0_0_3px_rgba(59,130,246,0.1)]'
+              : 'hover:border-primary-300 border-neutral-200 hover:shadow-md',
           ].join(' ')}
         >
-          <span
+          <div
             className={[
-              'inline-flex h-5 w-5 items-center justify-center',
-              selection === 'yes' ? 'text-primary-500' : 'text-neutral-400',
+              'flex h-14 w-14 items-center justify-center rounded-full transition-colors',
+              isYesActive ? 'bg-primary-400' : 'group-hover:bg-primary-100 bg-neutral-100',
             ].join(' ')}
           >
             <span
-              className="material-symbols-outlined leading-none"
-              style={{ fontSize: '20px' }}
+              className={[
+                'material-symbols-outlined transition-colors',
+                isYesActive ? 'text-white' : 'group-hover:text-primary-400 text-neutral-500',
+              ].join(' ')}
+              style={{ fontSize: '28px' }}
             >
-              {selection === 'yes' ? 'check_box' : 'check_box_outline_blank'}
+              folder_open
             </span>
-          </span>
-          <div className="flex flex-col">
-            <span className="text-body-4-bold text-neutral-900">네, 제출할 증거가 있어요.</span>
-            <span className="text-caption-regular text-neutral-600">
-              캡처본, 녹취, 진단서, 영수증 등 이미 가지고 있는 자료가 있습니다.
-            </span>
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <p
+              className={[
+                'text-body-2-bold transition-colors',
+                isYesActive ? 'text-primary-500' : 'text-neutral-800',
+              ].join(' ')}
+            >
+              네, 증거가 있어요
+            </p>
+            <p className="text-detail-regular text-neutral-400">
+              캡처본, 녹취, 진단서 등
+              <br />
+              제출할 자료가 있어요
+            </p>
           </div>
         </button>
 
+        {/* 아니요, 없어요 */}
         <button
           type="button"
-          onClick={() => setSelection('no')}
+          onClick={() => {
+            setSelection('no');
+            setError(null);
+          }}
           className={[
-            'rounded-300 flex w-full items-center gap-2 border px-4 py-3 text-left',
-            // ghost base
-            'to-neutral-0/10 bg-radial from-neutral-200/40 via-neutral-100/10',
-            'border',
-            'shadow-[inset_0_1px_2px_rgba(255,255,255,0.12)]',
-            'backdrop-blur-md',
-            'transition-all duration-300 ease-out',
-            // active vs default
+            'group relative flex w-full flex-col items-center justify-center gap-4',
+            'rounded-300 px-6 py-10',
+            'border-2 bg-white',
+            'transition-all duration-200 ease-out',
             isNoActive
-              ? 'border-primary-300 ring-primary-200 ring-2'
-              : 'hover:ring-primary-50/40 border-white/50 hover:border-white/70 hover:ring-2',
+              ? 'border-primary-400 bg-primary-0/30 shadow-[0_0_0_3px_rgba(59,130,246,0.1)]'
+              : 'hover:border-primary-300 border-neutral-200 hover:shadow-md',
           ].join(' ')}
         >
-          <span
+          <div
             className={[
-              'inline-flex h-5 w-5 items-center justify-center',
-              selection === 'no' ? 'text-primary-500' : 'text-neutral-400',
+              'flex h-14 w-14 items-center justify-center rounded-full transition-colors',
+              isNoActive ? 'bg-primary-400' : 'group-hover:bg-primary-100 bg-neutral-100',
             ].join(' ')}
           >
             <span
-              className="material-symbols-outlined leading-none"
-              style={{ fontSize: '20px' }}
+              className={[
+                'material-symbols-outlined transition-colors',
+                isNoActive ? 'text-white' : 'group-hover:text-primary-400 text-neutral-500',
+              ].join(' ')}
+              style={{ fontSize: '28px' }}
             >
-              {selection === 'no' ? 'check_box' : 'check_box_outline_blank'}
+              block
             </span>
-          </span>
-          <div className="flex flex-col">
-            <span className="text-body-4-bold text-neutral-900">
-              아니요, 아직 준비된 증거가 없어요.
-            </span>
-            <span className="text-caption-regular text-neutral-600">
-              지금 당장은 없지만, 이후에 증거를 확보할 수 있을 수도 있습니다.
-            </span>
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <p
+              className={[
+                'text-body-2-bold transition-colors',
+                isNoActive ? 'text-primary-500' : 'text-neutral-800',
+              ].join(' ')}
+            >
+              아니요, 없어요
+            </p>
+            <p className="text-detail-regular text-neutral-400">
+              지금은 없지만
+              <br />
+              이후에 확보할 수도 있어요
+            </p>
           </div>
         </button>
       </div>
-      {/* 경고 문구 */}
-      <FormErrorMessage error={error} />
-      <p className="text-body-3-regular mt-4 text-neutral-500">
-        * 증거가 없더라도 고소는 가능합니다.
-        <br />
-        &nbsp;&nbsp;다만 이후 수사 과정에서 추가 자료 제출이 필요할 수 있습니다.
-      </p>
+
+      <FormErrorMessage
+        error={error}
+        className="mt-4"
+      />
+
+      {/* 선택 결과에 따른 안내 */}
+      {selection && (
+        <div className="animate-fade-in mx-auto mt-4 w-full max-w-[520px]">
+          <div
+            className={[
+              'flex items-start gap-3 rounded-xl border px-4 py-3',
+              selection === 'yes'
+                ? 'border-primary-100 bg-primary-0/30'
+                : 'border-neutral-200 bg-neutral-50',
+            ].join(' ')}
+          >
+            <span
+              className={`material-symbols-outlined mt-0.5 ${selection === 'yes' ? 'text-primary-400' : 'text-neutral-400'}`}
+              style={{ fontSize: '18px' }}
+            >
+              {selection === 'yes' ? 'lightbulb' : 'info'}
+            </span>
+            <div className="flex flex-col gap-1">
+              {selection === 'yes' ? (
+                <>
+                  <p className="text-body-3-bold text-neutral-700">증거 제출 안내</p>
+                  <p className="text-detail-regular text-neutral-500">
+                    증거는 관할 경찰서에 고소장과 함께 직접 제출해주세요.
+                    <br />
+                    캡처본이나 녹취 파일은 USB에 담아가시면 편해요.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-body-3-bold text-neutral-700">걱정 마세요</p>
+                  <p className="text-detail-regular text-neutral-500">
+                    증거가 없어도 고소는 가능해요.
+                    <br />
+                    수사 과정에서 경찰이 증거 수집을 도와줄 수 있어요.
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </section>
   );
 });

--- a/src/features/complaint/stores/useComplaintWizard.ts
+++ b/src/features/complaint/stores/useComplaintWizard.ts
@@ -10,48 +10,49 @@ import type {
 const initialPrechecks: PrecheckQuestion[] = [
   {
     id: 'alreadyCriminalFiled',
-    title: '이 사건에 대해 형사 고소(고소장 제출)를 한 적이 있나요?',
+    title: '같은 사건으로 고소장을 낸 적이 있나요?',
     hintIcon: 'info',
     kind: 'binary',
     answer: null,
-    description: '이미 동일한 사건으로 형사 고소를 한 경우, 중복 접수로 처리될 수 있습니다.',
+    description:
+      '이미 같은 사건으로 고소장을 낸 적이 있다면, 경찰이나 검찰에서 "이미 처리된 사건"으로 보고 새 고소장을 받아주지 않을 수 있어요.',
   },
   {
     id: 'alreadyCivilFiled',
-    title: '이 사건에 대해 민사 소송(손해배상 청구 등)을 제기한 적이 있나요?',
+    title: '같은 사건으로 민사 소송을 진행한 적이 있나요?',
     hintIcon: 'info',
     kind: 'binary',
     answer: null,
     description:
-      '이미 동일한 사건으로 민사 소송을 진행 중인 경우, 형사 고소보다 민사 절차를 우선 검토해야 할 수 있습니다.',
+      '민사 소송은 돈이나 피해 보상을 받기 위한 절차예요. 이미 진행 중이라면 고소장 접수 전에 상황을 다시 확인해보는 게 좋아요.',
   },
   {
     id: 'withdrawnBefore',
-    title: '이 사건에 대해 취하한 적이 있나요?',
+    title: '같은 사건으로 고소를 취소한 적이 있나요?',
     hintIcon: 'info',
     kind: 'binary',
     answer: null,
     description:
-      '이전에 같은 사건을 취하한 이력이 있는 경우, 다시 고소하는 데 제한이 있을 수 있습니다.',
+      '한 번 취소한 고소는 다시 접수하기 어려울 수 있어요. 해당되신다면 법률 전문가와 먼저 상담해보시는 걸 추천드려요.',
   },
   {
     id: 'knowFalseAccusation',
-    title: '무고죄에 대해 알고 계신가요?',
+    title: '거짓 고소는 처벌받을 수 있어요',
     hintIcon: 'info',
     kind: 'confirm',
     confirmChip: {
       key: 'falseAccusationNotice',
-      label: '관련 안내를 확인했습니다.',
+      label: '확인했어요',
       checked: false,
     },
     description:
-      '고의로 사실이 아닌 내용을 신고하거나 타인을 범죄자로 만들기 위한 허위 고소는 무고죄에 해당할 수 있으며, 법적 처벌 대상이 될 수 있습니다.',
+      '사실이 아닌 내용으로 다른 사람을 고소하면 "무고죄"로 오히려 본인이 처벌받을 수 있어요. 작성하시는 내용이 사실에 기반한 것인지 꼭 확인해주세요.',
   },
 ];
 
 const INITIAL_STATE: ComplaintWizardState = {
   step: 0,
-  stepsTotal: 11,
+  stepsTotal: 9,
   prechecks: initialPrechecks,
   offense: null,
 };
@@ -197,7 +198,7 @@ export const useComplaintWizard = create<ComplaintWizardStore>((set, get) => ({
   percentage: () => {
     const { step, stepsTotal } = get().state;
     if (stepsTotal <= 1) return 0;
-    return Math.round(((step + 1) / stepsTotal) * 100);
+    return Math.round((step / (stepsTotal - 1)) * 100);
   },
 
   setOffense: (offense) =>

--- a/src/features/home/pages/MainPage.tsx
+++ b/src/features/home/pages/MainPage.tsx
@@ -57,15 +57,23 @@ export default function MainPage() {
       <Footer />
       {/* 로그인 유도 모달 (로그인 안 된 상태에서 고소장 작성 클릭 시) */}
       {showLoginPrompt && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4">
-          <CharacterModal
-            variant="login"
-            onCancel={() => setShowLoginPrompt(false)}
-            onConfirm={() => {
-              setShowLoginPrompt(false);
-              navigate('/login');
-            }}
-          />
+        <div
+          className="animate-overlay-in fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4"
+          onClick={() => setShowLoginPrompt(false)}
+        >
+          <div
+            className="animate-pop-in"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CharacterModal
+              variant="login"
+              onCancel={() => setShowLoginPrompt(false)}
+              onConfirm={() => {
+                setShowLoginPrompt(false);
+                navigate('/login');
+              }}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/features/home/sections/HeroSection.tsx
+++ b/src/features/home/sections/HeroSection.tsx
@@ -45,19 +45,36 @@ const HeroSection: React.FC<HeroSectionProps> = ({ onClickStart }) => {
             <br className="sm:hidden" /> 단계별로 쉽고 빠르게 완성해보세요.
           </p>
 
-          <Button
-            variant="primary"
-            size="lg"
-            className="group w-56 sm:w-64"
-            onClick={handleClick}
-          >
-            <span className="flex items-center justify-center gap-2">
-              고소장 작성 시작하기
-              <span className="material-symbols-outlined !text-[20px] transition-transform duration-300 group-hover:translate-x-1">
-                arrow_forward
+          <div className="flex flex-col items-center gap-3 sm:items-start">
+            <Button
+              variant="primary"
+              size="lg"
+              className="group w-56 sm:w-64"
+              onClick={handleClick}
+            >
+              <span className="flex items-center justify-center gap-2">
+                고소장 작성 시작하기
+                <span className="material-symbols-outlined !text-[20px] transition-transform duration-300 group-hover:translate-x-1">
+                  arrow_forward
+                </span>
               </span>
-            </span>
-          </Button>
+            </Button>
+            {user && (
+              <Button
+                variant="outline"
+                size="lg"
+                className="group w-56 sm:w-64"
+                onClick={() => navigate('/complaints')}
+              >
+                <span className="flex items-center justify-center gap-2">
+                  내 고소장 목록 보기
+                  <span className="material-symbols-outlined !text-[20px] transition-transform duration-300 group-hover:translate-x-1">
+                    arrow_forward
+                  </span>
+                </span>
+              </Button>
+            )}
+          </div>
         </div>
 
         {/* 캐릭터 영역 */}

--- a/src/features/my-complaints/pages/MyComplaintsPage.tsx
+++ b/src/features/my-complaints/pages/MyComplaintsPage.tsx
@@ -2,10 +2,11 @@ import { useNavigate } from 'react-router-dom';
 
 import React, { useEffect, useState } from 'react';
 
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
+
 import CharacterModal from '@/shared/ui/CharacterModal';
 import Footer from '@/shared/ui/Footer';
 import Header from '@/shared/ui/Header';
-import IntroHeader from '@/shared/ui/IntroHeader';
 import Button from '@/shared/ui/common/Button';
 
 import {
@@ -23,16 +24,6 @@ type MyComplaintItem = {
   ai_session_id?: string | null;
 };
 
-const STATUS_LABEL: Record<string, string> = {
-  in_progress: '작성 중',
-  completed: '작성 완료',
-};
-
-const STATUS_CHIP_CLASS: Record<string, string> = {
-  in_progress: 'bg-primary-0 text-primary-400 border border-primary-100',
-  completed: 'bg-neutral-0 text-neutral-600 border border-neutral-200',
-};
-
 const MyComplaintsPage: React.FC = () => {
   const navigate = useNavigate();
   const [items, setItems] = useState<MyComplaintItem[]>([]);
@@ -43,6 +34,10 @@ const MyComplaintsPage: React.FC = () => {
   const [downloadingId, setDownloadingId] = useState<number | null>(null);
 
   const resetWizard = useComplaintWizard((s) => s.reset);
+
+  const [filter, setFilter] = useState<'all' | 'in_progress' | 'completed'>('all');
+
+  const filteredItems = filter === 'all' ? items : items.filter((c) => c.status === filter);
 
   const fetchList = async () => {
     setLoading(true);
@@ -80,20 +75,19 @@ const MyComplaintsPage: React.FC = () => {
       return iso;
     }
   };
-  // 3) 이어쓰기
+
   const handleResume = (c: MyComplaintItem) => {
     resetWizard();
     navigate('/complaint', {
       state: {
-        mode: 'resume', // 이어쓰기 플래그
-        complaintId: Number(c.id), // 어떤 고소장인지
-        aiSessionId: c.ai_session_id ?? null, // 어떤 AI 세션인지
+        mode: 'resume',
+        complaintId: Number(c.id),
+        aiSessionId: c.ai_session_id ?? null,
         status: c.status,
       },
     });
   };
 
-  // 4) DOCX 다운로드
   const handleDownload = async (c: MyComplaintItem) => {
     try {
       setDownloadingId(c.id);
@@ -106,14 +100,12 @@ const MyComplaintsPage: React.FC = () => {
     }
   };
 
-  // 삭제 모달 오픈용
   const handleDelete = (c: MyComplaintItem) => {
     setDeleteTarget(c);
   };
 
   const confirmDelete = async () => {
     if (!deleteTarget) return;
-
     try {
       setDeletingId(deleteTarget.id);
       await deleteComplaint(deleteTarget.id);
@@ -127,196 +119,279 @@ const MyComplaintsPage: React.FC = () => {
     }
   };
 
+  const inProgressCount = items.filter((c) => c.status === 'in_progress').length;
+  const completedCount = items.filter((c) => c.status === 'completed').length;
+
   return (
-    <div className="bg-neutral-25 flex min-h-screen w-full flex-col">
+    <div className="flex min-h-screen w-full flex-col bg-neutral-50">
       <Header />
 
-      <main className="mx-auto flex w-full max-w-[1200px] flex-1 flex-col px-6 py-8">
-        {/* 🔹 상단 인트로 헤더 */}
-        <div className="mb-6">
-          <IntroHeader
-            title="내 고소장 관리"
-            lines={[
-              '내 고소장을 한 곳에서 확인할 수 있어요.',
-              '이어 작성하거나 내용을 확인하고, 필요 없는 고소장은 삭제할 수 있어요.',
-            ]}
-            center
-            showArrow={false}
-          />
-        </div>
-
-        {/* 오른쪽 상단 CTA 버튼 */}
-        <div className="mb-4 flex justify-end">
+      <main className="mx-auto flex w-full max-w-[800px] flex-1 flex-col px-6 py-8">
+        {/* 헤더 영역 */}
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h2 className="text-heading-3-bold text-neutral-900">내 고소장</h2>
+            <p className="text-body-3-regular mt-1 text-neutral-500">
+              작성한 고소장을 관리할 수 있어요.
+            </p>
+          </div>
           <Button
-            variant="outline"
-            size="md"
+            variant="primary"
+            size="sm"
             onClick={() => {
               resetWizard();
-              navigate('/complaint');
+              navigate('/complaint', { state: { mode: 'new' } });
             }}
           >
-            <span className="material-symbols-outlined text-primary-500 mr-2">edit_document</span>새
-            고소장 작성
+            <span
+              className="material-symbols-outlined mr-1"
+              style={{ fontSize: '18px' }}
+            >
+              add
+            </span>
+            새 고소장
           </Button>
         </div>
 
+        {/* 필터 탭 */}
+        {items.length > 0 && (
+          <div className="mb-6 grid grid-cols-3 gap-3">
+            <button
+              type="button"
+              onClick={() => setFilter('all')}
+              className={[
+                'rounded-xl border px-4 py-3 text-left transition-all',
+                filter === 'all'
+                  ? 'border-primary-400 bg-primary-0/30 shadow-sm'
+                  : 'hover:border-primary-200 border-neutral-200 bg-white',
+              ].join(' ')}
+            >
+              <p
+                className={`text-detail-regular ${filter === 'all' ? 'text-primary-400' : 'text-neutral-400'}`}
+              >
+                전체
+              </p>
+              <p
+                className={`text-body-1-bold ${filter === 'all' ? 'text-primary-500' : 'text-neutral-700'}`}
+              >
+                {items.length}건
+              </p>
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilter('in_progress')}
+              className={[
+                'rounded-xl border px-4 py-3 text-left transition-all',
+                filter === 'in_progress'
+                  ? 'border-primary-400 bg-primary-0/30 shadow-sm'
+                  : 'hover:border-primary-200 border-neutral-200 bg-white',
+              ].join(' ')}
+            >
+              <p
+                className={`text-detail-regular ${filter === 'in_progress' ? 'text-primary-400' : 'text-neutral-400'}`}
+              >
+                작성 중
+              </p>
+              <p
+                className={`text-body-1-bold ${filter === 'in_progress' ? 'text-primary-500' : 'text-neutral-700'}`}
+              >
+                {inProgressCount}건
+              </p>
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilter('completed')}
+              className={[
+                'rounded-xl border px-4 py-3 text-left transition-all',
+                filter === 'completed'
+                  ? 'border-primary-400 bg-primary-0/30 shadow-sm'
+                  : 'hover:border-primary-200 border-neutral-200 bg-white',
+              ].join(' ')}
+            >
+              <p
+                className={`text-detail-regular ${filter === 'completed' ? 'text-primary-400' : 'text-neutral-400'}`}
+              >
+                작성 완료
+              </p>
+              <p
+                className={`text-body-1-bold ${filter === 'completed' ? 'text-primary-500' : 'text-neutral-700'}`}
+              >
+                {completedCount}건
+              </p>
+            </button>
+          </div>
+        )}
+
         {/* 에러 메시지 */}
         {error && (
-          <div className="rounded-200 border-warning-100 bg-warning-25 text-body-3-regular text-warning-200 mb-4 border px-4 py-3">
+          <div className="border-warning-100 bg-warning-0 text-body-3-regular text-warning-200 mb-4 rounded-xl border px-4 py-3">
             {error}
           </div>
         )}
 
-        {/* 목록 카드 전체 래퍼 */}
-        <section
-          className={[
-            'rounded-300 bg-neutral-0 flex-1 border border-neutral-100',
-            'px-5 py-5',
-            'shadow-[0_8px_24px_rgba(15,23,42,0.04)]',
-          ].join(' ')}
-        >
-          {/* 상단 리스트 헤더 (카테고리 라벨) */}
-          <div className="mb-3 flex items-center justify-between border-b border-neutral-100 pb-3">
-            <div className="flex flex-col gap-0.5">
-              <h2 className="text-body-2-bold text-neutral-900">내 고소장 목록</h2>
-              <p className="text-caption-regular text-neutral-500">
-                총 {items.length}건의 고소장이 있어요.
-              </p>
-            </div>
+        {/* 목록 */}
+        {loading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <span
+              className="material-symbols-outlined text-primary-300 mb-2 animate-spin"
+              style={{ fontSize: '28px' }}
+            >
+              progress_activity
+            </span>
           </div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-4">
+            <img
+              src={characterUrl}
+              alt="바로 캐릭터"
+              className="h-24 w-24 opacity-60"
+              draggable={false}
+            />
+            <p className="text-body-2-regular text-neutral-400">아직 작성한 고소장이 없어요</p>
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => {
+                resetWizard();
+                navigate('/complaint');
+              }}
+            >
+              고소장 작성 시작하기
+            </Button>
+          </div>
+        ) : filteredItems.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 py-12">
+            <span
+              className="material-symbols-outlined text-neutral-300"
+              style={{ fontSize: '32px' }}
+            >
+              filter_list_off
+            </span>
+            <p className="text-body-3-regular text-neutral-400">
+              {filter === 'in_progress'
+                ? '작성 중인 고소장이 없어요'
+                : '작성 완료된 고소장이 없어요'}
+            </p>
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {filteredItems.map((c) => {
+              const isInProgress = c.status === 'in_progress';
+              const createdTime = new Date(c.created_at).getTime();
+              const canDownload =
+                c.status === 'completed' && Date.now() - createdTime <= 24 * 60 * 60 * 1000;
 
-          {/* 본문 */}
-          {loading ? (
-            <div className="flex h-40 items-center justify-center">
-              <p className="text-body-3-regular text-neutral-600">
-                고소장 목록을 불러오는 중입니다...
-              </p>
-            </div>
-          ) : items.length === 0 ? (
-            <div className="flex h-96 flex-col items-center justify-center gap-6">
-              <span
-                className="material-symbols-outlined text-neutral-200"
-                style={{ fontSize: '40px' }}
-              >
-                drafts
-              </span>
-              <p className="text-heading-3 text-neutral-400">아직 작성한 고소장이 없어요.</p>
-            </div>
-          ) : (
-            <ul className="flex flex-col gap-3">
-              {items.map((c) => {
-                const statusLabel = STATUS_LABEL[c.status] ?? c.status;
-                const statusClass = STATUS_CHIP_CLASS[c.status] ?? 'bg-neutral-50 text-neutral-600';
-
-                const createdTime = new Date(c.created_at).getTime();
-                const now = Date.now();
-                const ONE_DAY = 24 * 60 * 60 * 1000;
-                const canDownload = c.status === 'completed' && now - createdTime <= ONE_DAY;
-
-                return (
-                  <li
-                    key={c.id}
-                    className={[
-                      'rounded-250 border px-4 py-3',
-                      'flex flex-col gap-3 md:flex-row md:items-center md:justify-between',
-                      'bg-neutral-0 border-neutral-100',
-                      'hover:border-primary-50 hover:bg-primary-25/40',
-                      'transition-colors duration-200',
-                    ].join(' ')}
-                  >
-                    {/* 왼쪽: 기본 정보 */}
-                    <div className="flex flex-1 flex-col gap-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span className="text-body-3-bold text-neutral-900">고소장 #{c.id}</span>
-                        {c.crime_type && (
-                          <span className="rounded-200 bg-neutral-25 text-caption-regular px-2 py-0.5 text-neutral-600">
-                            {c.crime_type}
-                          </span>
-                        )}
-                        {/* 상태 뱃지 */}
+              return (
+                <li
+                  key={c.id}
+                  className="group hover:border-primary-200 rounded-2xl border border-neutral-200 bg-white px-5 py-4 shadow-sm transition-all duration-200 hover:shadow-md"
+                >
+                  {/* 상단: 정보 */}
+                  <div className="mb-3 flex items-start justify-between">
+                    <div className="flex flex-col gap-1">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="material-symbols-outlined text-primary-400"
+                          style={{ fontSize: '20px' }}
+                        >
+                          {isInProgress ? 'edit_note' : 'task'}
+                        </span>
+                        <span className="text-body-3-bold text-neutral-800">고소장 #{c.id}</span>
                         <span
                           className={[
-                            'rounded-400 inline-flex items-center px-2 py-1',
-                            'text-detail-regular',
-                            statusClass,
+                            'text-detail-regular rounded-full px-2 py-0.5',
+                            isInProgress
+                              ? 'bg-primary-0 text-primary-400'
+                              : 'bg-neutral-100 text-neutral-500',
                           ].join(' ')}
                         >
-                          {statusLabel}
+                          {isInProgress ? '작성 중' : '작성 완료'}
                         </span>
                       </div>
-                      <p className="text-caption-regular text-neutral-500">
-                        생성일시&nbsp;&nbsp;{formatDate(c.created_at)}
-                      </p>
-                    </div>
-
-                    {/* 오른쪽: 상태 + 액션들 */}
-                    <div className="flex flex-wrap items-center gap-2 md:justify-end">
-                      {/* 액션 버튼들 */}
-                      {c.status === 'in_progress' ? (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleResume(c)}
-                        >
-                          <span
-                            className="material-symbols-outlined text-primary-500"
-                            style={{ fontSize: '16px' }}
-                          >
-                            play_arrow
-                          </span>
-                          이어 쓰기
-                        </Button>
-                      ) : (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => canDownload && handleDownload(c)}
-                          disabled={!canDownload || downloadingId === c.id}
-                        >
-                          <span
-                            className="material-symbols-outlined"
-                            style={{ fontSize: '16px' }}
-                          >
-                            download
-                          </span>
-                          {canDownload
-                            ? downloadingId === c.id
-                              ? '다운로드 중...'
-                              : '고소장 다운로드'
-                            : '다운로드 기간 만료'}
-                        </Button>
+                      {c.crime_type && (
+                        <span className="text-detail-regular pl-7 text-neutral-500">
+                          {c.crime_type}
+                        </span>
                       )}
+                    </div>
+                    <span className="text-detail-regular text-neutral-400">
+                      {formatDate(c.created_at)}
+                    </span>
+                  </div>
 
+                  {/* 하단: 액션 */}
+                  <div className="flex items-center justify-end gap-2 border-t border-neutral-100 pt-3">
+                    {isInProgress ? (
                       <Button
-                        variant="secondary"
+                        variant="primary"
                         size="sm"
-                        onClick={() => handleDelete(c)}
-                        disabled={deletingId === c.id}
+                        onClick={() => handleResume(c)}
                       >
                         <span
-                          className="material-symbols-outlined text-inherit"
+                          className="material-symbols-outlined mr-1"
                           style={{ fontSize: '16px' }}
                         >
-                          delete
+                          play_arrow
                         </span>
-                        삭제
+                        이어 쓰기
                       </Button>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </section>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => canDownload && handleDownload(c)}
+                        disabled={!canDownload || downloadingId === c.id}
+                      >
+                        <span
+                          className="material-symbols-outlined mr-1"
+                          style={{ fontSize: '16px' }}
+                        >
+                          download
+                        </span>
+                        {canDownload
+                          ? downloadingId === c.id
+                            ? '다운로드 중...'
+                            : '다운로드'
+                          : '기간 만료'}
+                      </Button>
+                    )}
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => handleDelete(c)}
+                      disabled={deletingId === c.id}
+                    >
+                      <span
+                        className="material-symbols-outlined mr-1"
+                        style={{ fontSize: '16px' }}
+                      >
+                        delete
+                      </span>
+                      삭제
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </main>
 
       {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4">
-          <CharacterModal
-            variant="delete"
-            onCancel={() => setDeleteTarget(null)}
-            onConfirm={confirmDelete}
-          />
+        <div
+          className="animate-overlay-in fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4"
+          onClick={() => setDeleteTarget(null)}
+        >
+          <div
+            className="animate-pop-in"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CharacterModal
+              variant="delete"
+              onCancel={() => setDeleteTarget(null)}
+              onConfirm={confirmDelete}
+            />
+          </div>
         </div>
       )}
       <Footer />

--- a/src/shared/ui/CharacterModal.tsx
+++ b/src/shared/ui/CharacterModal.tsx
@@ -32,16 +32,10 @@ const CharacterModal: React.FC<Props> = ({ variant = 'login', onCancel, onConfir
     leftButtonText = '다음에 할게요';
     rightButtonText = '로그인';
   } else if (variant === 'exit') {
-    title = '정말 나가시겠어요?';
-    description = (
-      <>
-        지금 나가면 작성 중인 내용은
-        <br />
-        다시 복구할 수 없어요.
-      </>
-    );
-    leftButtonText = '계속 작성하기';
-    rightButtonText = '나가기';
+    title = '잠깐, 나가시겠어요?';
+    description = '작성 중인 고소장은 자동 저장돼요.';
+    leftButtonText = '이어서 작성';
+    rightButtonText = '나갈게요';
   } else {
     // delete
     title = '이 고소장을 삭제할까요?';

--- a/src/shared/ui/Chip.tsx
+++ b/src/shared/ui/Chip.tsx
@@ -10,54 +10,29 @@ export interface ChipProps {
 }
 
 const Chip: React.FC<ChipProps> = ({ active, onClick, label, colorScheme = 'primary' }) => {
-  const scheme =
+  const styles =
     colorScheme === 'warning'
-      ? {
-          activeBg: 'bg-warning-100',
-          inactiveBg: 'bg-warning-100/40',
-          ring: 'ring-warning-200/50',
-          text: active ? 'text-warning-200' : 'text-neutral-400',
-          label: 'text-warning-200',
-          focus: 'focus-visible:ring-warning-200',
-          hover: 'hover:bg-warning-100/80',
-        }
-      : {
-          activeBg: 'bg-primary-50',
-          inactiveBg: 'bg-primary-50/40',
-          ring: 'ring-primary-100',
-          text: active ? 'text-primary-400' : 'text-neutral-400',
-          label: 'text-primary-400',
-          focus: 'focus-visible:ring-primary-200',
-          hover: 'hover:bg-primary-100/80',
-        };
+      ? active
+        ? 'bg-warning-200 text-white ring-warning-200'
+        : 'bg-neutral-100 text-neutral-500 ring-neutral-200 hover:bg-neutral-200/60'
+      : active
+        ? 'bg-primary-400 text-white ring-primary-400'
+        : 'bg-neutral-100 text-neutral-500 ring-neutral-200 hover:bg-neutral-200/60';
 
   return (
     <button
       type="button"
       onClick={onClick}
       className={[
-        'rounded-300 inline-flex h-6 items-center gap-2 px-3',
-        active ? scheme.activeBg : scheme.inactiveBg,
-        'ring-1',
-        scheme.ring,
-        scheme.hover,
-        'focus:outline-none',
-        'focus-visible:ring-2',
-        scheme.focus,
-        'transition-colors',
+        'rounded-300 inline-flex h-8 items-center px-4',
+        'text-body-3-regular transition-all duration-200',
+        'ring-1 focus:outline-none',
+        active ? 'font-semibold' : '',
+        styles,
       ].join(' ')}
       aria-pressed={!!active}
     >
-      {/* 체크 아이콘 */}
-      <span
-        className={['material-symbols-outlined leading-none', scheme.text].join(' ')}
-        style={{ fontSize: '16px' }}
-        aria-hidden
-      >
-        {active ? 'check_box' : 'check_box_outline_blank'}
-      </span>
-      {/* 라벨 텍스트 */}
-      <span className={['text-detail-regular', scheme.label].join(' ')}>{label}</span>
+      {label}
     </button>
   );
 };

--- a/src/shared/ui/DaumPostcodeButton.tsx
+++ b/src/shared/ui/DaumPostcodeButton.tsx
@@ -52,7 +52,7 @@ const DaumPostcodeButton: React.FC<Props> = ({ onSelect, address }) => {
   // 주소 선택 완료 상태
   if (hasAddress) {
     return (
-      <div className="rounded-200 border-primary-200 bg-primary-0/50 flex h-8 w-full items-center gap-3 border px-3">
+      <div className="rounded-200 border-primary-200 bg-primary-0/50 flex h-9 w-full items-center gap-3 border px-3">
         <span className="text-body-3-regular flex-1 text-neutral-900">
           {[address.city, address.district, address.town].filter(Boolean).join(' ')}
         </span>
@@ -74,7 +74,7 @@ const DaumPostcodeButton: React.FC<Props> = ({ onSelect, address }) => {
       <button
         type="button"
         onClick={handleOpen}
-        className="rounded-200 hover:border-primary-300 hover:bg-primary-0/30 flex h-8 w-full items-center gap-3 border border-dashed border-neutral-300 px-3 text-left transition-colors"
+        className="rounded-200 hover:border-primary-300 hover:bg-primary-0/30 flex h-9 w-full items-center gap-3 border border-neutral-300 px-3 text-left transition-colors"
       >
         <span
           className="material-symbols-outlined text-neutral-400"

--- a/src/shared/ui/Footer.tsx
+++ b/src/shared/ui/Footer.tsx
@@ -23,7 +23,7 @@ const Footer: React.FC = () => {
   const navigate = useNavigate();
 
   return (
-    <footer className="w-full snap-end border-t border-neutral-200 bg-neutral-50">
+    <footer className="w-full shrink-0 snap-end border-t border-neutral-200 bg-neutral-50">
       <div className="mx-auto w-full max-w-[1280px] px-8 pt-4 pb-2">
         {/* 상단 영역 */}
         <div className="flex flex-col gap-6 sm:flex-row sm:justify-between">

--- a/src/shared/ui/FormErrorMessage.tsx
+++ b/src/shared/ui/FormErrorMessage.tsx
@@ -22,7 +22,15 @@ const FormErrorMessage: React.FC<FormErrorMessageProps> = ({ error, className = 
         className="text-detail-regular text-warning-300"
         role="alert"
       >
-        {error}
+        {error
+          .split(/(?<=\.)\s*/)
+          .filter(Boolean)
+          .map((sentence, i, arr) => (
+            <React.Fragment key={i}>
+              {sentence}
+              {i < arr.length - 1 && <br />}
+            </React.Fragment>
+          ))}
       </p>
     </div>
   );

--- a/src/shared/ui/GeneratingModal.tsx
+++ b/src/shared/ui/GeneratingModal.tsx
@@ -4,54 +4,45 @@ import BaLawCharacterLarge from '@/assets/BaLawCharacter-large.svg';
 
 type GeneratingModalProps = {
   open: boolean;
-  title?: string;
-  description?: string;
 };
 
-const GeneratingModal: React.FC<GeneratingModalProps> = ({ open, title, description }) => {
+const GeneratingModal: React.FC<GeneratingModalProps> = ({ open }) => {
   if (!open) return null;
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4"
+      className="animate-overlay-in fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 px-4"
       role="dialog"
       aria-modal="true"
       aria-label="고소장 생성 중"
     >
       <div
         className={[
-          'relative flex w-full max-w-sm flex-col items-center',
-          'rounded-400 from-primary-0 to-primary-400 bg-gradient-to-b',
-          'px-6 py-10 sm:px-10 sm:py-14',
-          'shadow-lg',
+          'animate-pop-in relative flex w-full max-w-sm flex-col items-center',
+          'rounded-2xl bg-white',
+          'px-8 py-10',
+          'shadow-[0_16px_40px_rgba(15,23,42,0.2)]',
         ].join(' ')}
       >
-        {/* 텍스트 영역 */}
-        <div className="flex flex-col items-center gap-2 text-center">
-          <p className="text-body-1-bold sm:text-heading-4-bold text-primary-900">
-            {title ?? 'AI가 고소장을 작성하고 있어요.'}
-          </p>
-          <p className="text-detail-regular sm:text-body-3-regular text-neutral-600">
-            {description ?? (
-              <>
-                입력해 주신 내용을 바탕으로
-                <br />
-                고소장 초안을 정리하는 중입니다.
-              </>
-            )}
-          </p>
-        </div>
+        {/* 캐릭터 */}
+        <img
+          src={BaLawCharacterLarge}
+          alt="바로 캐릭터"
+          className="animate-float mb-6 h-32 w-32"
+          draggable={false}
+        />
 
-        {/* 로딩 인디케이터 + 캐릭터 */}
-        <div className="mt-6 flex flex-col items-center gap-3">
-          <div className="border-primary-200 border-t-primary-100 h-8 w-8 animate-spin rounded-full border-4" />
-          {/* 캐릭터 이미지 */}
-          <img
-            src={BaLawCharacterLarge}
-            alt="바로 캐릭터"
-            className="h-52 w-52 object-contain"
-          />
-          <p className="text-detail-regular text-neutral-200">잠시만 기다려 주세요...</p>
+        {/* 타이핑 애니메이션 텍스트 */}
+        <div className="flex flex-col items-center gap-3">
+          <p className="animate-typing text-body-2-bold text-neutral-800">
+            바로가 고소장을 작성하고 있어요
+          </p>
+          <p className="animate-typing-delay-1 text-body-3-regular text-neutral-500">
+            입력해 주신 내용을 바탕으로 초안을 정리 중이에요
+          </p>
+          <p className="animate-typing-delay-2 text-detail-regular text-neutral-400">
+            조금만 기다려 주세요, 거의 다 됐어요!
+          </p>
         </div>
       </div>
     </div>

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -18,17 +18,17 @@ const Header: React.FC = () => {
 
   useEffect(() => {
     const handleScroll = () => {
-      // main 태그가 스크롤 컨테이너인 경우 대응
-      const scrollContainer = document.querySelector('main');
-      const scrollY = scrollContainer ? scrollContainer.scrollTop : window.scrollY;
-      setScrolled(scrollY > 10);
+      const mainEl = document.querySelector('main');
+      const mainScroll = mainEl ? mainEl.scrollTop : 0;
+      setScrolled(mainScroll > 10 || window.scrollY > 10);
     };
 
-    const scrollContainer = document.querySelector('main');
-    const target = scrollContainer || window;
-    target.addEventListener('scroll', handleScroll, { passive: true });
+    const mainEl = document.querySelector('main');
+    const targets: (HTMLElement | Window)[] = [window];
+    if (mainEl) targets.push(mainEl);
 
-    return () => target.removeEventListener('scroll', handleScroll);
+    targets.forEach((t) => t.addEventListener('scroll', handleScroll, { passive: true }));
+    return () => targets.forEach((t) => t.removeEventListener('scroll', handleScroll));
   }, []);
 
   const handleLoginClick = () => navigate('/login');

--- a/src/shared/ui/IntroHeader.tsx
+++ b/src/shared/ui/IntroHeader.tsx
@@ -1,58 +1,65 @@
-import React, { useMemo } from 'react';
+import React from 'react';
+
+import characterUrl from '@/assets/BaLawCharacter-large.svg';
 
 const IntroHeader: React.FC<{
-  title: string;
+  title?: string;
   lines?: string[];
   center?: boolean;
   className?: string;
   showArrow?: boolean;
-}> = ({ title, lines = [], center = true, className = '', showArrow = true }) => {
-  const align = center ? 'items-center text-center' : 'items-start text-left';
-
-  const renderedLines = useMemo(
-    () =>
-      lines.map((text, idx) => (
-        <p
-          key={text}
-          className={
-            idx === 0
-              ? 'text-body-1-regular text-neutral-900'
-              : 'text-body-3-regular text-neutral-500'
-          }
-        >
-          {text}
-        </p>
-      )),
-    [lines],
-  );
+}> = ({ lines = [], className = '' }) => {
+  if (lines.length === 0) return null;
 
   return (
-    <div className={`flex w-full flex-col justify-start ${align} ${className}`}>
-      <h2 className="text-heading-1-bold text-primary-400 w-full max-w-[500px]">{title}</h2>
+    <div className={`mt-4 mb-6 flex items-start gap-3 md:mt-6 md:mb-8 md:gap-4 ${className}`}>
+      {/* 바로 캐릭터 */}
+      <img
+        src={characterUrl}
+        alt="바로 캐릭터"
+        className="animate-float h-14 w-14 shrink-0 md:h-18 md:w-18 lg:h-22 lg:w-22"
+        draggable={false}
+      />
 
-      {lines.length > 0 && <div className="flex flex-col pt-2">{renderedLines}</div>}
-
-      {showArrow && (
-        <div
-          className="flex items-center justify-center"
-          aria-hidden="true"
-          style={{ width: 24, height: 24 }}
+      {/* 말풍선 */}
+      <div className="animate-bubble-in rounded-200 border-primary-100 bg-primary-0/40 relative flex-1 border px-4 py-3 md:px-5 md:py-4">
+        {/* 말풍선 꼬리 */}
+        <svg
+          className="absolute top-5 -left-[6px] md:top-6"
+          width="6"
+          height="10"
+          viewBox="0 0 6 10"
+          fill="none"
         >
-          <span
-            className="material-symbols-outlined bg-clip-text pt-3 leading-none text-transparent"
-            style={{
-              fontSize: 24,
-              opacity: 0.5,
-              backgroundImage:
-                'linear-gradient(to bottom, var(--color-neutral-700), var(--color-primary-400))',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent',
-            }}
-          >
-            arrow_cool_down
-          </span>
+          <path
+            d="M6 0 L0 5 L6 10"
+            className="fill-primary-0/40 stroke-primary-100"
+            strokeWidth="1"
+          />
+          <line
+            x1="6"
+            y1="0"
+            x2="6"
+            y2="10"
+            className="stroke-primary-0/40"
+            strokeWidth="2"
+          />
+        </svg>
+        <div className="flex flex-col gap-0.5">
+          {lines.map((text, idx) => (
+            <p
+              key={text}
+              className={
+                idx === 0
+                  ? 'text-body-3-regular md:text-body-2-regular lg:text-body-1-regular text-neutral-700'
+                  : 'text-detail-regular md:text-body-3-regular text-neutral-500'
+              }
+            >
+              {text}
+            </p>
+          ))}
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -147,6 +147,12 @@
     @apply font-sans;
   }
 
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
   html {
     scroll-behavior: smooth;
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -73,6 +73,248 @@
     }
   }
 
+  /* 🎈 캐릭터 둥실둥실 애니메이션 */
+  @keyframes float {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-6px);
+    }
+  }
+
+  .animate-float {
+    animation: float 3s ease-in-out infinite;
+  }
+
+  /* 💬 말풍선 등장 애니메이션 */
+  @keyframes bubbleIn {
+    from {
+      opacity: 0;
+      transform: scale(0.92) translateX(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateX(0);
+    }
+  }
+
+  .animate-bubble-in {
+    animation: bubbleIn 0.4s ease-out both;
+    animation-delay: 0.3s;
+    opacity: 0;
+  }
+
+  /* 🎈 캐릭터 뿅 등장 애니메이션 */
+  @keyframes popIn {
+    0% {
+      opacity: 0;
+      transform: scale(0.3);
+    }
+    60% {
+      opacity: 1;
+      transform: scale(1.08);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .animate-pop-in {
+    animation: popIn 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
+  /* 💬 말풍선 위로 열리기 애니메이션 */
+  @keyframes bubbleUp {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.9);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  .animate-bubble-up {
+    animation: bubbleUp 0.4s ease-out both;
+    animation-delay: 0.4s;
+    opacity: 0;
+  }
+
+  /* 📜 카드 → 모달 확장 애니메이션 */
+  @keyframes expandCard {
+    0% {
+      transform: scale(0.4) translateY(20%);
+      opacity: 0;
+      border-radius: 16px;
+    }
+    50% {
+      opacity: 1;
+    }
+    100% {
+      transform: scale(1) translateY(0);
+      opacity: 1;
+      border-radius: 16px;
+    }
+  }
+
+  @keyframes overlayIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  .animate-expand-card {
+    animation: expandCard 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+    transform-origin: right center;
+  }
+
+  .animate-overlay-in {
+    animation: overlayIn 0.25s ease-out both;
+  }
+
+  /* ✍️ 타이핑 애니메이션 */
+  @keyframes typing {
+    from {
+      width: 0;
+    }
+    to {
+      width: 100%;
+    }
+  }
+
+  @keyframes blink {
+    0%,
+    100% {
+      border-color: transparent;
+    }
+    50% {
+      border-color: var(--color-primary-400);
+    }
+  }
+
+  /* 1줄: 타이핑, 커서 깜빡 후 사라짐 */
+  .animate-typing {
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    max-width: fit-content;
+    border-right: 2px solid transparent;
+    animation-name: typing, blink;
+    animation-duration: 3s, 1s;
+    animation-timing-function: steps(30, end), step-end;
+    animation-fill-mode: forwards, none;
+    animation-iteration-count: 1, 4;
+    animation-delay: 0s, 0s;
+  }
+
+  /* 2줄: 타이핑, 커서 깜빡 후 사라짐 */
+  .animate-typing-delay-1 {
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 0;
+    max-width: fit-content;
+    border-right: 2px solid transparent;
+    animation-name: typing, blink;
+    animation-duration: 3.5s, 1s;
+    animation-timing-function: steps(35, end), step-end;
+    animation-fill-mode: forwards, none;
+    animation-iteration-count: 1, 5;
+    animation-delay: 4.5s, 4.5s;
+  }
+
+  /* 3줄: 타이핑, 커서 계속 깜빡 */
+  .animate-typing-delay-2 {
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 0;
+    max-width: fit-content;
+    border-right: 2px solid transparent;
+    animation-name: typing, blink;
+    animation-duration: 3s, 1s;
+    animation-timing-function: steps(25, end), step-end;
+    animation-fill-mode: forwards, none;
+    animation-iteration-count: 1, infinite;
+    animation-delay: 9.5s, 9.5s;
+  }
+
+  /* 📖 책 페이지 넘기기 애니메이션 */
+  @keyframes flipPage1 {
+    0%,
+    100% {
+      transform: rotateY(0deg);
+    }
+    20% {
+      transform: rotateY(-160deg);
+    }
+    40%,
+    60% {
+      transform: rotateY(-160deg);
+    }
+    80% {
+      transform: rotateY(0deg);
+    }
+  }
+
+  @keyframes flipPage2 {
+    0%,
+    15% {
+      transform: rotateY(0deg);
+    }
+    30% {
+      transform: rotateY(-160deg);
+    }
+    50%,
+    65% {
+      transform: rotateY(-160deg);
+    }
+    80%,
+    100% {
+      transform: rotateY(0deg);
+    }
+  }
+
+  @keyframes flipPage3 {
+    0%,
+    25% {
+      transform: rotateY(0deg);
+    }
+    40% {
+      transform: rotateY(-160deg);
+    }
+    55%,
+    70% {
+      transform: rotateY(-160deg);
+    }
+    85%,
+    100% {
+      transform: rotateY(0deg);
+    }
+  }
+
+  .animate-book-page-1 {
+    animation: flipPage1 3s ease-in-out infinite;
+    transform-origin: left center;
+  }
+
+  .animate-book-page-2 {
+    animation: flipPage2 3s ease-in-out infinite;
+    transform-origin: left center;
+  }
+
+  .animate-book-page-3 {
+    animation: flipPage3 3s ease-in-out infinite;
+    transform-origin: left center;
+  }
+
   /* 🧵 BaLaw 커스텀 스크롤바 */
   .balaw-scrollbar {
     /* Firefox용 */


### PR DESCRIPTION
* [Design] 진행률바 + 네비게이션 버튼 리디자인

* [Design] IntroHeader 캐릭터 말풍선 + 안내 문구 통일

* [Design] 안내 확인 단계 카드형 질문 + 칩 리디자인

* [Design] 입력 폼 카드 그룹형 + 주소/전화번호 통일

* [Design] 시작/증거/채팅안내 단계 카드 선택 리디자인

* [Design] 채팅창 + AI 분석 패널 전면 개편

* [Fix] 레이아웃 수정 (푸터/스크롤 이슈)

* [Design] 판례 열리는 인터랙션 추가

* [Design] 판례 아코디언 + 모달 제거 + 애니메이션 추가

* [Design] 고소장 미리보기 + 다운로드 리디자인

* [Feat] 히어로 섹션에 내 고소장 페이지 연결 버튼 추가 (로그인 한 경우에만 보임)

* [Design] 내 고소장 목록 페이지 리디자인

* [Feat] 내 고소장 목록에서 새 고소장 클릭 시 시작 단계 자동 스킵

* [Design] 고소인/피고소인 ID 카드 미리보기 추가 및 카드 너비 통일

* [Refactor] 고소인 & 피고소인 정보 입력 단계 통합 및 폼 UX 개선

* [Refactor] 고소인 & 피고소인 정보 통합 및 폼 UX 개선

* [Design] 증거 선택 안내 + 채팅 UX + 고소장 생성 모달 개선

* [Design] 모달 인터랙션 개선

* [Fix] 사용하지 않는 import 제거
