### PR TITLE
[Fix] 채팅 히스토리 API 응답 구조 변경에 따른 수정

### DIFF
--- a/src/features/complaint/apis/complaints.ts
+++ b/src/features/complaint/apis/complaints.ts
@@ -86,6 +86,13 @@ export type ChatMessageHistoryItem = {
   created_at: string;
 };
 
+export type ChatHistoryResponse = {
+  messages: ChatMessageHistoryItem[];
+  offense?: string | null;
+  rag_keyword?: string | null;
+  rag_cases?: RagCase[] | null;
+};
+
 /** 고소인 정보 등록 */
 export async function createComplaint(data: ComplainantInfoCreate): Promise<Complaint> {
   const res = await api.post(`${BASE_URL}/complaints/info/complainant`, data);
@@ -181,10 +188,9 @@ export async function getMyComplaints() {
 }
 
 /** 채팅 히스토리 */
-export async function getChatHistory(complaintId: number): Promise<ChatMessageHistoryItem[]> {
+export async function getChatHistory(complaintId: number): Promise<ChatHistoryResponse> {
   const res = await api.get(`${BASE_URL}/complaints/${complaintId}/chat/history`);
-  const data = res.data as { messages: ChatMessageHistoryItem[] };
-  return data.messages ?? [];
+  return res.data as ChatHistoryResponse;
 }
 
 /** 삭제 */

--- a/src/features/complaint/sections/ChatWindowSection.tsx
+++ b/src/features/complaint/sections/ChatWindowSection.tsx
@@ -2,7 +2,11 @@ import type { AxiosError } from 'axios';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-import type { ChatMetaPayload, RagCase } from '@/features/complaint/apis/complaints';
+import type {
+  ChatHistoryResponse,
+  ChatMetaPayload,
+  RagCase,
+} from '@/features/complaint/apis/complaints';
 import {
   type ChatMessageHistoryItem,
   getChatHistory,
@@ -196,31 +200,24 @@ const ChatWindowSection: React.FC<Props> = ({
 
     const loadHistory = async () => {
       try {
-        const history: ChatMessageHistoryItem[] = await getChatHistory(complaintId);
+        const response: ChatHistoryResponse = await getChatHistory(complaintId);
+        const history = response.messages ?? [];
 
-        if (!history || history.length === 0) {
-          // 히스토리도 없고 ai_session_id도 없으면 사건 경위 입력 단계로
+        if (history.length === 0) {
           if (!initialAiSessionId) {
             setPhase('askSummary');
           }
-          // AI 질문 내역이 없으니 사건 경위 입력을 한 번 더 안내
           setMsgs([...introMsgs(), caseSummaryMsg()]);
         } else {
           const restored: Msg[] = [];
-          let lastMeta: ChatMetaPayload | undefined;
 
           const AUTO_MSG = '위 사건 개요를 기반으로, 이어서 질문을 해 주세요.';
 
           history.forEach((msg, idx) => {
-            if (isAiMetaMessage(msg.content)) {
-              lastMeta = msg.content;
-              return;
-            }
+            // 서버가 메타 메시지를 이미 필터링하지만, 하위호환을 위해 방어적으로 체크
+            if (isAiMetaMessage(msg.content)) return;
 
-            // 자동 발송 메시지는 히스토리에서 숨김
-            if (typeof msg.content === 'string' && msg.content === AUTO_MSG) {
-              return;
-            }
+            if (typeof msg.content === 'string' && msg.content === AUTO_MSG) return;
 
             const text =
               typeof msg.content === 'string'
@@ -236,7 +233,6 @@ const ChatWindowSection: React.FC<Props> = ({
             });
           });
 
-          // 백엔드 히스토리에 실제 AI 질문이 있었는지 확인
           const hasAiQuestion = history.some(
             (msg) =>
               msg.role === 'assistant' &&
@@ -244,7 +240,6 @@ const ChatWindowSection: React.FC<Props> = ({
               msg.content !== AUTO_MSG,
           );
 
-          // AI 질문이 있었고 마지막이 사용자 답변이면, 이어서 답변하도록 안내
           const last = history[history.length - 1];
           if (hasAiQuestion && last && last.role === 'user') {
             restored.push({
@@ -255,10 +250,8 @@ const ChatWindowSection: React.FC<Props> = ({
             });
           }
 
-          // 맨 위에 인트로 + 선택 유형 요약, AI 질문이 없으면 사건 경위 안내를 마지막에 추가
           setMsgs([...introMsgs(), ...restored, ...(hasAiQuestion ? [] : [caseSummaryMsg()])]);
 
-          // 히스토리 안에 DONE_PHRASE가 있으면 완료 상태로 취급
           const hasDone = history.some(
             (msg) =>
               msg.role === 'assistant' &&
@@ -268,15 +261,17 @@ const ChatWindowSection: React.FC<Props> = ({
 
           if (hasDone) {
             setIsCompleted(true);
-            onComplete?.(); // 부모(ComplaintWizardPage)의 isChatCompleted = true
+            onComplete?.();
           }
 
-          if (lastMeta) {
+          // 메타 정보를 응답 최상위 필드에서 가져옴 (서버가 complaints 테이블에서 제공)
+          const hasResponseMeta =
+            response.offense || response.rag_keyword || response.rag_cases?.length;
+          if (hasResponseMeta) {
             onInitMeta?.({
-              // 죄목 라벨은 사용자가 고른 값을 우선 사용
-              offense: saved?.offense || lastMeta.offense || '',
-              rag_keyword: lastMeta.rag_keyword ?? null,
-              rag_cases: lastMeta.rag_cases ?? [],
+              offense: saved?.offense || response.offense || '',
+              rag_keyword: response.rag_keyword ?? null,
+              rag_cases: response.rag_cases ?? [],
             });
           } else if (saved) {
             onInitMeta?.({ offense: saved.offense, rag_keyword: null, rag_cases: [] });


### PR DESCRIPTION
### ✅ PR 설명

채팅 히스토리 API 응답 구조 변경에 따른 수정

### 🏗 작업 내용

- [x] ChatHistoryResponse 타입 추가 (messages + offense + rag_keyword + rag_cases)
- [x] getChatHistory() 반환 타입을 배열에서 응답 객체로 변경
- [x] 이어쓰기 시 메타 정보를 메시지 파싱 대신 응답 최상위 필드에서 추출하도록 수정
- [x] 기존 메타 메시지 방어 로직은 하위호환용으로 유지

### 📸 테스트 결과 (선택)


### 🔗 관련 이슈 (선택)


### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
